### PR TITLE
[JAV-566] report type/version when register to SC

### DIFF
--- a/foundations/foundation-common/src/main/java/io/servicecomb/foundation/common/base/ServiceCombConstants.java
+++ b/foundations/foundation-common/src/main/java/io/servicecomb/foundation/common/base/ServiceCombConstants.java
@@ -49,4 +49,12 @@ public interface ServiceCombConstants {
   String CONFIG_CSE_PREFIX = "cse.";
 
   String CONFIG_KEY_SPLITER = "_";
+
+  String CONFIG_MICROSERVICE_DEVELOPMENT_FRAMEWORK_KEY = "framework.name";
+
+  String DEFAULT_MICROSERVICE_DEVELOPMENT_FRAMEWORK = "UNKNOWN";
+
+  String CONFIG_MICROSERVICE_DEVELOPMENT_FRAMEWORK_VERSION_KEY = "framework.version";
+
+  String CONFIG_MICROSERVICE_REGISTER_WAY_KEY = "registerBy";
 }

--- a/service-registry/src/main/java/io/servicecomb/serviceregistry/api/registry/Microservice.java
+++ b/service-registry/src/main/java/io/servicecomb/serviceregistry/api/registry/Microservice.java
@@ -23,6 +23,7 @@ import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import io.servicecomb.serviceregistry.api.Const;
 
@@ -32,6 +33,11 @@ import io.servicecomb.serviceregistry.api.Const;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Microservice {
   private String serviceId;
+
+  private Map<String, String> framework = new HashMap<>();
+
+  @JsonProperty(value = "registerBy")
+  private String registeredBy;
 
   private String appId;
 
@@ -172,4 +178,21 @@ public class Microservice {
   public void setPaths(List<BasePath> paths) {
     this.paths = paths;
   }
+
+  public Map<String, String> getFramework() {
+    return framework;
+  }
+
+  public void setFramework(Map<String, String> framework) {
+    this.framework = framework;
+  }
+
+  public String getRegisteredBy() {
+    return registeredBy;
+  }
+
+  public void setRegisteredBy(String registeredBy) {
+    this.registeredBy = registeredBy;
+  }
+
 }

--- a/service-registry/src/main/java/io/servicecomb/serviceregistry/api/registry/MicroserviceFactory.java
+++ b/service-registry/src/main/java/io/servicecomb/serviceregistry/api/registry/MicroserviceFactory.java
@@ -20,11 +20,16 @@ import static io.servicecomb.foundation.common.base.ServiceCombConstants.CONFIG_
 import static io.servicecomb.foundation.common.base.ServiceCombConstants.CONFIG_QUALIFIED_MICROSERVICE_NAME_KEY;
 import static io.servicecomb.foundation.common.base.ServiceCombConstants.CONFIG_QUALIFIED_MICROSERVICE_ROLE_KEY;
 import static io.servicecomb.foundation.common.base.ServiceCombConstants.CONFIG_QUALIFIED_MICROSERVICE_VERSION_KEY;
+import static io.servicecomb.foundation.common.base.ServiceCombConstants.CONFIG_MICROSERVICE_DEVELOPMENT_FRAMEWORK_KEY;
+import static io.servicecomb.foundation.common.base.ServiceCombConstants.CONFIG_MICROSERVICE_DEVELOPMENT_FRAMEWORK_VERSION_KEY;
+import static io.servicecomb.foundation.common.base.ServiceCombConstants.CONFIG_MICROSERVICE_REGISTER_WAY_KEY;
 import static io.servicecomb.foundation.common.base.ServiceCombConstants.DEFAULT_MICROSERVICE_NAME;
+import static io.servicecomb.foundation.common.base.ServiceCombConstants.DEFAULT_MICROSERVICE_DEVELOPMENT_FRAMEWORK;
 import static io.servicecomb.serviceregistry.definition.DefinitionConst.CONFIG_ALLOW_CROSS_APP_KEY;
 import static io.servicecomb.serviceregistry.definition.DefinitionConst.DEFAULT_APPLICATION_ID;
 import static io.servicecomb.serviceregistry.definition.DefinitionConst.DEFAULT_MICROSERVICE_VERSION;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.commons.configuration.Configuration;
@@ -64,6 +69,16 @@ public class MicroserviceFactory {
       microservice.setAlias(Microservice.generateAbsoluteMicroserviceName(microservice.getAppId(),
           microservice.getServiceName()));
     }
+    
+    Map<String, String> framework = new HashMap<>();
+    framework.put("name", configuration.getString(CONFIG_MICROSERVICE_DEVELOPMENT_FRAMEWORK_KEY, DEFAULT_MICROSERVICE_DEVELOPMENT_FRAMEWORK));
+    framework.put("version", configuration.getString(CONFIG_MICROSERVICE_DEVELOPMENT_FRAMEWORK_VERSION_KEY, ""));
+    microservice.setFramework(framework);
+    String str = "";
+    if (configuration.getString(CONFIG_MICROSERVICE_REGISTER_WAY_KEY, "") != null) {
+      str = configuration.getString(CONFIG_MICROSERVICE_REGISTER_WAY_KEY, "");
+    }
+    microservice.setRegisteredBy(MicroserviceRegisterWay.find(str).toString());
 
     return microservice;
   }

--- a/service-registry/src/main/java/io/servicecomb/serviceregistry/api/registry/MicroserviceRegisterWay.java
+++ b/service-registry/src/main/java/io/servicecomb/serviceregistry/api/registry/MicroserviceRegisterWay.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017 Huawei Technologies Co., Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.servicecomb.serviceregistry.api.registry;
+
+/**
+ * Created by   on 2017/12/15.
+ */
+public enum MicroserviceRegisterWay {
+  SDK,
+  PLATFORM,
+  SIDECAR,
+  UNKNOWN;
+  public static MicroserviceRegisterWay find(String type) {
+    switch (type) {
+      case "SDK":
+        return SDK;
+      case "PLATFORM":
+        return PLATFORM;
+      case "SIDECAR":
+        return SIDECAR;
+      default:
+        return UNKNOWN;
+    }
+  }
+}

--- a/service-registry/src/test/java/io/servicecomb/serviceregistry/api/registry/TestMicroService.java
+++ b/service-registry/src/test/java/io/servicecomb/serviceregistry/api/registry/TestMicroService.java
@@ -32,12 +32,15 @@ public class TestMicroService {
 
   Map<String, String> oMapProperties = null;
 
+  Map<String, String> oMapFramework = null;
+
   List<String> oListSchemas = null;
 
   @Before
   public void setUp() throws Exception {
     oMicroservice = new Microservice();
     oMapProperties = new HashMap<>();
+    oMapFramework = new HashMap<>();
     oListSchemas = new ArrayList<>();
   }
 
@@ -60,6 +63,8 @@ public class TestMicroService {
     Assert.assertEquals(MicroserviceInstanceStatus.UP.toString(), oMicroservice.getStatus());
     Assert.assertNull(oMicroservice.getVersion());
     Assert.assertEquals(0, oMicroservice.getPaths().size());
+    Assert.assertEquals(0, oMicroservice.getFramework().size());
+    Assert.assertNull(oMicroservice.getRegisteredBy());
   }
 
   @Test
@@ -75,6 +80,9 @@ public class TestMicroService {
     Assert.assertEquals("fakeProxy", oMicroservice.getProperties().get("proxy"));
     Assert.assertEquals(1, oMicroservice.getSchemas().size());
     Assert.assertEquals(1, oMicroservice.getPaths().size());
+    Assert.assertEquals("JAVA-CHASSIS", oMicroservice.getFramework().get("name"));
+    Assert.assertEquals("0.4.0", oMicroservice.getFramework().get("version"));
+    Assert.assertEquals("SDK", oMicroservice.getRegisteredBy());
   }
 
   private void initMicroservice() {
@@ -90,5 +98,9 @@ public class TestMicroService {
     oMicroservice.setProperties(oMapProperties);
     oMicroservice.setSchemas(oListSchemas);
     oMicroservice.getPaths().add(new BasePath());
+    oMapFramework.put("name", "JAVA-CHASSIS");
+    oMapFramework.put("version", "0.4.0");
+    oMicroservice.setFramework(oMapFramework);
+    oMicroservice.setRegisteredBy("SDK");
   }
 }


### PR DESCRIPTION
1. SDK report their framework type and version when register to SC
2. Each service with specific version has a certain framework+version
3. Present the type/version information in console in Service+Version level
4. In gov service, send the different command to CC according to the type/version when doing management