### PR TITLE
[JAV-590] add null pointer check in ClassUtils

### DIFF
--- a/swagger/swagger-generator/generator-core/src/main/java/io/servicecomb/swagger/generator/core/utils/ClassUtils.java
+++ b/swagger/swagger-generator/generator-core/src/main/java/io/servicecomb/swagger/generator/core/utils/ClassUtils.java
@@ -133,13 +133,15 @@ public final class ClassUtils {
     ClassConfig classConfig = new ClassConfig();
     classConfig.setClassName(clsName);
 
-    for (Entry<String, Property> entry : properties.entrySet()) {
-      JavaType propertyJavaType =
-          ConverterMgr.findJavaType(classLoader,
-              packageName,
-              swagger,
-              entry.getValue());
-      classConfig.addField(entry.getKey(), propertyJavaType);
+    if (null != properties) {
+      for (Entry<String, Property> entry : properties.entrySet()) {
+        JavaType propertyJavaType =
+            ConverterMgr.findJavaType(classLoader,
+                packageName,
+                swagger,
+                entry.getValue());
+        classConfig.addField(entry.getKey(), propertyJavaType);
+      }
     }
 
     cls = JavassistUtils.createClass(classLoader, classConfig);


### PR DESCRIPTION
Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://https://servicecomb.atlassian.net/projects/JAV/issues) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Format the pull request title like `[JAV-XXX] Fixes bug in ApproximateQuantiles`, where you replace `JAV-XXX` with the appropriate JIRA issue.
 - [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [ ] Run `mvn clean install` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---

See details in [https://servicecomb.atlassian.net/browse/JAV-590](https://servicecomb.atlassian.net/browse/JAV-590). 
Check whether the parameter `properties` is null in ClassUtils.getOrCreateClass() to avoid NullPointerException.