### PR TITLE
[JAV-558] pullTask,use rev to ensure data consistency and reduce service center work load

### DIFF
--- a/service-registry/src/main/java/io/servicecomb/serviceregistry/RegistryUtils.java
+++ b/service-registry/src/main/java/io/servicecomb/serviceregistry/RegistryUtils.java
@@ -20,7 +20,6 @@ package io.servicecomb.serviceregistry;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.List;
 import java.util.Map;
 
 import org.apache.http.client.utils.URIBuilder;
@@ -38,6 +37,7 @@ import io.servicecomb.serviceregistry.api.registry.Microservice;
 import io.servicecomb.serviceregistry.api.registry.MicroserviceInstance;
 import io.servicecomb.serviceregistry.cache.InstanceCacheManager;
 import io.servicecomb.serviceregistry.client.ServiceRegistryClient;
+import io.servicecomb.serviceregistry.client.http.MicroserviceInstances;
 import io.servicecomb.serviceregistry.config.ServiceRegistryConfig;
 import io.servicecomb.serviceregistry.definition.MicroserviceDefinition;
 import io.servicecomb.serviceregistry.registry.ServiceRegistryFactory;
@@ -202,9 +202,9 @@ public final class RegistryUtils {
     return new IpPort(publicAddressSetting, publishPort);
   }
 
-  public static List<MicroserviceInstance> findServiceInstance(String appId, String serviceName,
-      String versionRule) {
-    return serviceRegistry.findServiceInstance(appId, serviceName, versionRule);
+  public static MicroserviceInstances findServiceInstance(String appId, String serviceName,
+      String versionRule, String revision) {
+    return serviceRegistry.findServiceInstance(appId, serviceName, versionRule, revision);
   }
 
   // update microservice instance properties

--- a/service-registry/src/main/java/io/servicecomb/serviceregistry/ServiceRegistry.java
+++ b/service-registry/src/main/java/io/servicecomb/serviceregistry/ServiceRegistry.java
@@ -16,7 +16,6 @@
  */
 package io.servicecomb.serviceregistry;
 
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -24,6 +23,7 @@ import io.servicecomb.serviceregistry.api.registry.Microservice;
 import io.servicecomb.serviceregistry.api.registry.MicroserviceInstance;
 import io.servicecomb.serviceregistry.cache.InstanceCacheManager;
 import io.servicecomb.serviceregistry.client.ServiceRegistryClient;
+import io.servicecomb.serviceregistry.client.http.MicroserviceInstances;
 import io.servicecomb.serviceregistry.consumer.AppManager;
 
 public interface ServiceRegistry {
@@ -45,8 +45,8 @@ public interface ServiceRegistry {
 
   InstanceCacheManager getInstanceCacheManager();
 
-  List<MicroserviceInstance> findServiceInstance(String appId, String microserviceName,
-      String microserviceVersionRule);
+  MicroserviceInstances findServiceInstance(String appId, String microserviceName,
+      String microserviceVersionRule, String revision);
 
   boolean updateMicroserviceProperties(Map<String, String> properties);
 

--- a/service-registry/src/main/java/io/servicecomb/serviceregistry/client/LocalServiceRegistryClientImpl.java
+++ b/service-registry/src/main/java/io/servicecomb/serviceregistry/client/LocalServiceRegistryClientImpl.java
@@ -38,8 +38,11 @@ import org.yaml.snakeyaml.Yaml;
 import io.servicecomb.foundation.vertx.AsyncResultCallback;
 import io.servicecomb.serviceregistry.api.registry.Microservice;
 import io.servicecomb.serviceregistry.api.registry.MicroserviceInstance;
+import io.servicecomb.serviceregistry.api.response.FindInstancesResponse;
 import io.servicecomb.serviceregistry.api.response.HeartbeatResponse;
 import io.servicecomb.serviceregistry.api.response.MicroserviceInstanceChangedEvent;
+import io.servicecomb.serviceregistry.client.http.MicroserviceInstances;
+import io.servicecomb.serviceregistry.definition.DefinitionConst;
 import io.servicecomb.serviceregistry.version.Version;
 import io.servicecomb.serviceregistry.version.VersionRule;
 import io.servicecomb.serviceregistry.version.VersionRuleUtils;
@@ -238,14 +241,19 @@ public class LocalServiceRegistryClientImpl implements ServiceRegistryClient {
   }
 
   @Override
-  public List<MicroserviceInstance> findServiceInstance(String selfMicroserviceId, String appId, String serviceName,
-      String strVersionRule) {
+  public MicroserviceInstances findServiceInstance(String selfMicroserviceId, String appId, String serviceName,
+      String strVersionRule, String revision) {
     List<MicroserviceInstance> allInstances = new ArrayList<>();
+    MicroserviceInstances microserviceInstances = new MicroserviceInstances();
+    FindInstancesResponse response = new FindInstancesResponse();
 
     VersionRule versionRule = VersionRuleUtils.getOrCreate(strVersionRule);
     Microservice latestMicroservice = findLatest(appId, serviceName, versionRule);
     if (latestMicroservice == null) {
-      return allInstances;
+      response.setInstances(allInstances);
+      microserviceInstances.setInstancesResponse(response);
+      microserviceInstances.setRevision(DefinitionConst.DEFAULT_REVISION);
+      return microserviceInstances;
     }
 
     Version latestVersion = VersionUtils.getOrCreate(latestMicroservice.getVersion());
@@ -263,8 +271,10 @@ public class LocalServiceRegistryClientImpl implements ServiceRegistryClient {
       Map<String, MicroserviceInstance> instances = microserviceInstanceMap.get(entry.getValue().getServiceId());
       allInstances.addAll(instances.values());
     }
+    response.setInstances(allInstances);
+    microserviceInstances.setInstancesResponse(response);
 
-    return allInstances;
+    return microserviceInstances;
   }
 
   @Override

--- a/service-registry/src/main/java/io/servicecomb/serviceregistry/client/ServiceRegistryClient.java
+++ b/service-registry/src/main/java/io/servicecomb/serviceregistry/client/ServiceRegistryClient.java
@@ -25,6 +25,7 @@ import io.servicecomb.serviceregistry.api.registry.Microservice;
 import io.servicecomb.serviceregistry.api.registry.MicroserviceInstance;
 import io.servicecomb.serviceregistry.api.response.HeartbeatResponse;
 import io.servicecomb.serviceregistry.api.response.MicroserviceInstanceChangedEvent;
+import io.servicecomb.serviceregistry.client.http.MicroserviceInstances;
 
 public interface ServiceRegistryClient {
   void init();
@@ -120,10 +121,10 @@ public interface ServiceRegistryClient {
 
   /**
    *
-   * 按照app+interface+version查询实例endpoints信息
+   * 按照app+interface+version+revision查询实例endpoints信息
    */
-  List<MicroserviceInstance> findServiceInstance(String consumerId, String appId, String serviceName,
-      String versionRule);
+  MicroserviceInstances findServiceInstance(String consumerId, String appId, String serviceName,
+      String versionRule, String revision);
   
   /**
    * 通过serviceId， instanceId 获取instance对象。

--- a/service-registry/src/main/java/io/servicecomb/serviceregistry/client/http/MicroserviceInstances.java
+++ b/service-registry/src/main/java/io/servicecomb/serviceregistry/client/http/MicroserviceInstances.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.servicecomb.serviceregistry.client.http;
+
+import io.servicecomb.serviceregistry.api.response.FindInstancesResponse;
+
+/**
+ * Created by on 2017/12/28.
+ */
+public class MicroserviceInstances {
+  private boolean needRefresh = true;
+
+  private String revision;
+
+  private FindInstancesResponse instancesResponse;
+
+  public boolean isNeedRefresh() {
+    return needRefresh;
+  }
+
+  public void setNeedRefresh(boolean needRefresh) {
+    this.needRefresh = needRefresh;
+  }
+
+  public String getRevision() {
+    return revision;
+  }
+
+  public void setRevision(String revision) {
+    this.revision = revision;
+  }
+
+  public FindInstancesResponse getInstancesResponse() {
+    return instancesResponse;
+  }
+
+  public void setInstancesResponse(FindInstancesResponse instancesResponse) {
+    this.instancesResponse = instancesResponse;
+  }
+
+}

--- a/service-registry/src/main/java/io/servicecomb/serviceregistry/client/http/ServiceRegistryClientImpl.java
+++ b/service-registry/src/main/java/io/servicecomb/serviceregistry/client/http/ServiceRegistryClientImpl.java
@@ -111,7 +111,7 @@ public final class ServiceRegistryClientImpl implements ServiceRegistryClient {
               holder.value =
                   JsonUtils.readValue(bodyBuffer.getBytes(), cls);
             } catch (Exception e) {
-              LOGGER.warn(bodyBuffer.toString());
+              LOGGER.warn(bodyBuffer.toString(), e);
             }
             countDownLatch.countDown();
           });
@@ -148,6 +148,36 @@ public final class ServiceRegistryClientImpl implements ServiceRegistryClient {
         holder.value = responseWrapper;
         countDownLatch.countDown();
       });
+    };
+  }
+
+  private <T> Handler<RestResponse> syncHandlerForInstances(CountDownLatch countDownLatch, MicroserviceInstances mInstances) {
+    return restResponse -> {
+      RequestContext requestContext = restResponse.getRequestContext();
+      HttpClientResponse response = restResponse.getResponse();
+      if (response == null) {
+        // 请求失败，触发请求SC的其他实例
+        if (!requestContext.isRetry()) {
+          retry(requestContext, syncHandlerForInstances(countDownLatch, mInstances));
+        } else {
+          countDownLatch.countDown();
+        }
+        return;
+      }
+      response.bodyHandler(
+          bodyBuffer -> {
+            try {
+              mInstances.setRevision(response.getHeader("X-Resource-Revision"));
+              if (response.statusCode() == 304) {
+                mInstances.setNeedRefresh(false);
+              } else {
+                mInstances.setInstancesResponse(JsonUtils.readValue(bodyBuffer.getBytes(), FindInstancesResponse.class));
+              }
+            } catch (Exception e) {
+              LOGGER.warn(bodyBuffer.toString(), e);
+            }
+            countDownLatch.countDown();
+          });
     };
   }
 
@@ -516,9 +546,9 @@ public final class ServiceRegistryClientImpl implements ServiceRegistryClient {
   }
 
   @Override
-  public List<MicroserviceInstance> findServiceInstance(String consumerId, String appId, String serviceName,
-      String versionRule) {
-    Holder<FindInstancesResponse> holder = new Holder<>();
+  public MicroserviceInstances findServiceInstance(String consumerId, String appId, String serviceName,
+      String versionRule, String revision) {
+    MicroserviceInstances microserviceInstances = new MicroserviceInstances();
     IpPort ipPort = ipPortManager.getAvailableAddress(false);
 
     CountDownLatch countDownLatch = new CountDownLatch(1);
@@ -527,18 +557,22 @@ public final class ServiceRegistryClientImpl implements ServiceRegistryClient {
         new RequestParam().addQueryParam("appId", appId)
             .addQueryParam("serviceName", serviceName)
             .addQueryParam("version", versionRule)
+            .addQueryParam("rev", revision)
             .addHeader("X-ConsumerId", consumerId),
-        syncHandler(countDownLatch, FindInstancesResponse.class, holder));
+        syncHandlerForInstances(countDownLatch, microserviceInstances));
     try {
       countDownLatch.await();
-      if (holder.value == null) {
+      if (!microserviceInstances.isNeedRefresh()) {
+        return microserviceInstances;
+      }
+      if (microserviceInstances.getInstancesResponse() == null) {
         return null; // error
       }
-      List<MicroserviceInstance> list = holder.value.getInstances();
+      List<MicroserviceInstance> list = microserviceInstances.getInstancesResponse().getInstances();
       if (list == null) {
-        return new ArrayList<>();
+        microserviceInstances.getInstancesResponse().setInstances(new ArrayList<>());
       }
-      return list;
+      return microserviceInstances;
     } catch (Exception e) {
       LOGGER.error("find microservice instance {}/{}/{} failed",
           appId,

--- a/service-registry/src/main/java/io/servicecomb/serviceregistry/consumer/MicroserviceVersions.java
+++ b/service-registry/src/main/java/io/servicecomb/serviceregistry/consumer/MicroserviceVersions.java
@@ -33,6 +33,7 @@ import io.servicecomb.serviceregistry.RegistryUtils;
 import io.servicecomb.serviceregistry.api.registry.MicroserviceInstance;
 import io.servicecomb.serviceregistry.api.registry.MicroserviceInstanceStatus;
 import io.servicecomb.serviceregistry.api.response.MicroserviceInstanceChangedEvent;
+import io.servicecomb.serviceregistry.client.http.MicroserviceInstances;
 import io.servicecomb.serviceregistry.definition.DefinitionConst;
 import io.servicecomb.serviceregistry.task.event.PullMicroserviceVersionsInstancesEvent;
 
@@ -44,6 +45,8 @@ public class MicroserviceVersions {
   private String appId;
 
   private String microserviceName;
+
+  private String revision = DefinitionConst.DEFAULT_REVISION;
 
   private List<MicroserviceInstance> instances;
 
@@ -90,6 +93,14 @@ public class MicroserviceVersions {
     return (T) versions.get(serviceId);
   }
 
+  public String getRevision() {
+    return revision;
+  }
+
+  public void setRevision(String revision) {
+    this.revision = revision;
+  }
+
   public void submitPull() {
     pendingPullCount.incrementAndGet();
     pullInstances();
@@ -100,17 +111,23 @@ public class MicroserviceVersions {
       return;
     }
 
-    List<MicroserviceInstance> pulledInstances = RegistryUtils.findServiceInstance(appId,
+    MicroserviceInstances microserviceInstances = RegistryUtils.findServiceInstance(appId,
         microserviceName,
-        DefinitionConst.VERSION_RULE_ALL);
-    if (pulledInstances == null) {
+        DefinitionConst.VERSION_RULE_ALL,
+        revision);
+    if (microserviceInstances == null) {
       return;
     }
+    if (!microserviceInstances.isNeedRefresh()) {
+      return;
+    }
+    List<MicroserviceInstance> pulledInstances = microserviceInstances.getInstancesResponse().getInstances();
+    String rev = microserviceInstances.getRevision();
 
-    setInstances(pulledInstances);
+    setInstances(pulledInstances, rev);
   }
 
-  private void setInstances(List<MicroserviceInstance> pulledInstances) {
+  private void setInstances(List<MicroserviceInstance> pulledInstances, String rev) {
     synchronized (lock) {
       instances = pulledInstances
           .stream()
@@ -133,6 +150,7 @@ public class MicroserviceVersions {
       for (MicroserviceVersionRule microserviceVersionRule : versionRules.values()) {
         microserviceVersionRule.setInstances(instances);
       }
+      revision = rev;
     }
   }
 

--- a/service-registry/src/main/java/io/servicecomb/serviceregistry/definition/DefinitionConst.java
+++ b/service-registry/src/main/java/io/servicecomb/serviceregistry/definition/DefinitionConst.java
@@ -34,4 +34,6 @@ public interface DefinitionConst {
   String VERSION_RULE_LATEST = "latest";
 
   String VERSION_RULE_ALL = "0.0.0+";
+
+  String DEFAULT_REVISION = "0";
 }

--- a/service-registry/src/test/java/io/servicecomb/serviceregistry/TestRegistry.java
+++ b/service-registry/src/test/java/io/servicecomb/serviceregistry/TestRegistry.java
@@ -47,6 +47,7 @@ import io.servicecomb.config.ConfigUtil;
 import io.servicecomb.foundation.common.net.NetUtils;
 import io.servicecomb.serviceregistry.api.registry.Microservice;
 import io.servicecomb.serviceregistry.api.registry.MicroserviceInstance;
+import io.servicecomb.serviceregistry.client.http.MicroserviceInstances;
 import io.servicecomb.serviceregistry.registry.ServiceRegistryFactory;
 import mockit.Deencapsulation;
 import mockit.Expectations;
@@ -94,7 +95,8 @@ public class TestRegistry {
     Assert.assertEquals(serviceRegistry.getMicroservice(), microservice);
     Assert.assertEquals(serviceRegistry.getMicroserviceInstance(), RegistryUtils.getMicroserviceInstance());
 
-    List<MicroserviceInstance> instanceList = RegistryUtils.findServiceInstance("default", "default", "0.0.1");
+    MicroserviceInstances microserviceInstances = RegistryUtils.findServiceInstance("default", "default", "0.0.1", "0");
+    List<MicroserviceInstance> instanceList = microserviceInstances.getInstancesResponse().getInstances();
     Assert.assertEquals(1, instanceList.size());
     Assert.assertEquals(RegistryUtils.getMicroservice().getServiceId(), instanceList.get(0).getServiceId());
 

--- a/service-registry/src/test/java/io/servicecomb/serviceregistry/client/LocalServiceRegistryClientImplTest.java
+++ b/service-registry/src/test/java/io/servicecomb/serviceregistry/client/LocalServiceRegistryClientImplTest.java
@@ -30,6 +30,7 @@ import org.junit.rules.ExpectedException;
 
 import io.servicecomb.serviceregistry.api.registry.Microservice;
 import io.servicecomb.serviceregistry.api.registry.MicroserviceInstance;
+import io.servicecomb.serviceregistry.client.http.MicroserviceInstances;
 import io.servicecomb.serviceregistry.definition.DefinitionConst;
 
 public class LocalServiceRegistryClientImplTest {
@@ -53,8 +54,9 @@ public class LocalServiceRegistryClientImplTest {
   public void testLoadRegistryFile() {
     Assert.assertNotNull(registryClient);
     Assert.assertThat(registryClient.getAllMicroservices().size(), Is.is(1));
-    List<MicroserviceInstance> m =
-        registryClient.findServiceInstance("", "myapp", "springmvctest", DefinitionConst.VERSION_RULE_ALL);
+    MicroserviceInstances microserviceInstances =
+        registryClient.findServiceInstance("", "myapp", "springmvctest", DefinitionConst.VERSION_RULE_ALL, DefinitionConst.DEFAULT_REVISION);
+    List<MicroserviceInstance> m = microserviceInstances.getInstancesResponse().getInstances();
     Assert.assertEquals(1, m.size());
   }
 
@@ -109,8 +111,9 @@ public class LocalServiceRegistryClientImplTest {
 
   @Test
   public void findServiceInstance_noInstances() {
-    List<MicroserviceInstance> result =
-        registryClient.findServiceInstance("self", appId, microserviceName, DefinitionConst.VERSION_RULE_ALL);
+    MicroserviceInstances microserviceInstances =
+        registryClient.findServiceInstance("self", appId, microserviceName, DefinitionConst.VERSION_RULE_ALL, DefinitionConst.DEFAULT_REVISION);
+    List<MicroserviceInstance> result = microserviceInstances.getInstancesResponse().getInstances();
 
     Assert.assertThat(result, Matchers.empty());
   }
@@ -124,8 +127,9 @@ public class LocalServiceRegistryClientImplTest {
     instance.setServiceId(v1.getServiceId());
     registryClient.registerMicroserviceInstance(instance);
 
-    List<MicroserviceInstance> result =
-        registryClient.findServiceInstance("self", appId, microserviceName, "1.0.0");
+    MicroserviceInstances microserviceInstances =
+        registryClient.findServiceInstance("self", appId, microserviceName, "1.0.0", "0");
+    List<MicroserviceInstance> result = microserviceInstances.getInstancesResponse().getInstances();
 
     Assert.assertThat(result, Matchers.contains(instance));
   }

--- a/service-registry/src/test/java/io/servicecomb/serviceregistry/client/http/TestClientHttp.java
+++ b/service-registry/src/test/java/io/servicecomb/serviceregistry/client/http/TestClientHttp.java
@@ -82,7 +82,8 @@ public class TestClientHttp {
         oClient.findServiceInstance(microservice.getServiceId(),
             microservice.getAppId(),
             microservice.getServiceName(),
-            microservice.getVersion()));
+            microservice.getVersion(),
+            "0"));
     Assert.assertEquals(null,
         oClient.getMicroserviceId(microservice.getAppId(),
             microservice.getServiceName(),

--- a/service-registry/src/test/java/io/servicecomb/serviceregistry/client/http/TestMicroserviceInstances.java
+++ b/service-registry/src/test/java/io/servicecomb/serviceregistry/client/http/TestMicroserviceInstances.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.servicecomb.serviceregistry.client.http;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import io.servicecomb.serviceregistry.api.registry.MicroserviceInstance;
+import io.servicecomb.serviceregistry.api.response.FindInstancesResponse;
+
+public class TestMicroserviceInstances {
+
+  MicroserviceInstances microserviceInstances = null;
+
+  FindInstancesResponse findInstancesResponse = null;
+
+  List<MicroserviceInstance> instances = null;
+
+  @Before
+  public void setUp() throws Exception {
+    microserviceInstances = new MicroserviceInstances();
+    findInstancesResponse = new FindInstancesResponse();
+    instances = new ArrayList<>();
+    instances.add(Mockito.mock(MicroserviceInstance.class));
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    instances = null;
+    microserviceInstances = null;
+    findInstancesResponse = null;
+  }
+
+  @Test
+  public void testDefaultValues() {
+    Assert.assertNull(microserviceInstances.getInstancesResponse());
+    Assert.assertTrue(microserviceInstances.isNeedRefresh());
+    Assert.assertNull(microserviceInstances.getRevision());
+    Assert.assertNull(findInstancesResponse.getInstances());
+  }
+
+  @Test
+  public void testInitializedValues() {
+    initFields(); //Initialize the Object
+    Assert.assertEquals(1, microserviceInstances.getInstancesResponse().getInstances().size());
+    Assert.assertFalse(microserviceInstances.isNeedRefresh());
+    Assert.assertEquals("1", microserviceInstances.getRevision());
+  }
+
+  private void initFields() {
+    findInstancesResponse.setInstances(instances);
+    microserviceInstances.setInstancesResponse(findInstancesResponse);
+    microserviceInstances.setNeedRefresh(false);
+    microserviceInstances.setRevision("1");
+  }
+
+}

--- a/service-registry/src/test/java/io/servicecomb/serviceregistry/client/http/TestServiceRegistryClientImpl.java
+++ b/service-registry/src/test/java/io/servicecomb/serviceregistry/client/http/TestServiceRegistryClientImpl.java
@@ -124,7 +124,7 @@ public class TestServiceRegistryClientImpl {
         oClient.unregisterMicroserviceInstance("microserviceId", "microserviceInstanceId"));
     Assert.assertEquals(null, oClient.heartbeat("microserviceId", "microserviceInstanceId"));
     Assert.assertEquals(null,
-        oClient.findServiceInstance("selfMicroserviceId", "appId", "serviceName", "versionRule"));
+        oClient.findServiceInstance("selfMicroserviceId", "appId", "serviceName", "versionRule", "0"));
 
     Assert.assertEquals("a", new ClientException("a").getMessage());
   }

--- a/service-registry/src/test/java/io/servicecomb/serviceregistry/consumer/TestAppManager.java
+++ b/service-registry/src/test/java/io/servicecomb/serviceregistry/consumer/TestAppManager.java
@@ -19,12 +19,16 @@ package io.servicecomb.serviceregistry.consumer;
 
 import java.util.Collections;
 
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 import com.google.common.eventbus.EventBus;
 
 import io.servicecomb.serviceregistry.RegistryUtils;
+import io.servicecomb.serviceregistry.api.response.FindInstancesResponse;
+import io.servicecomb.serviceregistry.client.http.MicroserviceInstances;
 import io.servicecomb.serviceregistry.definition.DefinitionConst;
 import mockit.Expectations;
 import mockit.Mocked;
@@ -40,12 +44,30 @@ public class TestAppManager {
 
   String versionRule = "0+";
 
+  MicroserviceInstances microserviceInstances = null;
+
+  FindInstancesResponse findInstancesResponse = null;
+
+  @Before
+  public void setUp() throws Exception {
+    microserviceInstances = new MicroserviceInstances();
+    findInstancesResponse = new FindInstancesResponse();
+    findInstancesResponse.setInstances(Collections.emptyList());
+    microserviceInstances.setInstancesResponse(findInstancesResponse);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    findInstancesResponse = null;
+    microserviceInstances = null;
+  }
+
   @Test
   public void getOrCreateMicroserviceVersionRule() {
     new Expectations(RegistryUtils.class) {
       {
-        RegistryUtils.findServiceInstance(appId, serviceName, DefinitionConst.VERSION_RULE_ALL);
-        result = Collections.emptyList();
+        RegistryUtils.findServiceInstance(appId, serviceName, DefinitionConst.VERSION_RULE_ALL, DefinitionConst.DEFAULT_REVISION);
+        result = microserviceInstances;
       }
     };
 
@@ -59,8 +81,8 @@ public class TestAppManager {
   public void getOrCreateMicroserviceVersions() {
     new Expectations(RegistryUtils.class) {
       {
-        RegistryUtils.findServiceInstance(appId, serviceName, DefinitionConst.VERSION_RULE_ALL);
-        result = Collections.emptyList();
+        RegistryUtils.findServiceInstance(appId, serviceName, DefinitionConst.VERSION_RULE_ALL, DefinitionConst.DEFAULT_REVISION);
+        result = microserviceInstances;
       }
     };
 

--- a/service-registry/src/test/java/io/servicecomb/serviceregistry/consumer/TestMicroserviceManager.java
+++ b/service-registry/src/test/java/io/servicecomb/serviceregistry/consumer/TestMicroserviceManager.java
@@ -22,12 +22,16 @@ import java.util.Map;
 
 import javax.xml.ws.Holder;
 
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 import com.google.common.eventbus.EventBus;
 
 import io.servicecomb.serviceregistry.RegistryUtils;
+import io.servicecomb.serviceregistry.api.response.FindInstancesResponse;
+import io.servicecomb.serviceregistry.client.http.MicroserviceInstances;
 import io.servicecomb.serviceregistry.definition.DefinitionConst;
 import io.servicecomb.serviceregistry.task.event.PeriodicPullEvent;
 import io.servicecomb.serviceregistry.task.event.RecoveryEvent;
@@ -49,12 +53,30 @@ public class TestMicroserviceManager {
 
   MicroserviceManager microserviceManager = new MicroserviceManager(appManager, appId);
 
+  MicroserviceInstances microserviceInstances = null;
+
+  FindInstancesResponse findInstancesResponse = null;
+
+  @Before
+  public void setUp() throws Exception {
+    microserviceInstances = new MicroserviceInstances();
+    findInstancesResponse = new FindInstancesResponse();
+    findInstancesResponse.setInstances(Collections.emptyList());
+    microserviceInstances.setInstancesResponse(findInstancesResponse);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    findInstancesResponse = null;
+    microserviceInstances = null;
+  }
+
   @Test
   public void getOrCreateMicroserviceVersionRule() {
     new Expectations(RegistryUtils.class) {
       {
-        RegistryUtils.findServiceInstance(appId, serviceName, DefinitionConst.VERSION_RULE_ALL);
-        result = Collections.emptyList();
+        RegistryUtils.findServiceInstance(appId, serviceName, DefinitionConst.VERSION_RULE_ALL, DefinitionConst.DEFAULT_REVISION);
+        result = microserviceInstances;
       }
     };
 

--- a/service-registry/src/test/java/io/servicecomb/serviceregistry/consumer/TestMicroserviceVersions.java
+++ b/service-registry/src/test/java/io/servicecomb/serviceregistry/consumer/TestMicroserviceVersions.java
@@ -23,7 +23,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 import com.google.common.eventbus.EventBus;
@@ -34,7 +36,9 @@ import io.servicecomb.serviceregistry.api.MicroserviceKey;
 import io.servicecomb.serviceregistry.api.registry.Microservice;
 import io.servicecomb.serviceregistry.api.registry.MicroserviceInstance;
 import io.servicecomb.serviceregistry.api.registry.MicroserviceInstanceStatus;
+import io.servicecomb.serviceregistry.api.response.FindInstancesResponse;
 import io.servicecomb.serviceregistry.api.response.MicroserviceInstanceChangedEvent;
+import io.servicecomb.serviceregistry.client.http.MicroserviceInstances;
 import io.servicecomb.serviceregistry.task.event.PullMicroserviceVersionsInstancesEvent;
 import io.servicecomb.serviceregistry.version.Version;
 import mockit.Deencapsulation;
@@ -60,6 +64,22 @@ public class TestMicroserviceVersions {
 
   AtomicInteger pendingPullCount;
 
+  MicroserviceInstances microserviceInstances = null;
+
+  FindInstancesResponse findInstancesResponse = null;
+
+  @Before
+  public void setUp() throws Exception {
+    microserviceInstances = new MicroserviceInstances();
+    findInstancesResponse = new FindInstancesResponse();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    findInstancesResponse = null;
+    microserviceInstances = null;
+  }
+
   public TestMicroserviceVersions() {
     microserviceVersions = new MicroserviceVersions(appManager, appId, microserviceName);
     pendingPullCount = Deencapsulation.getField(microserviceVersions, "pendingPullCount");
@@ -81,15 +101,23 @@ public class TestMicroserviceVersions {
     instances.add(instance);
   }
 
+  private void createMicroserviceInstances() {
+    findInstancesResponse.setInstances(instances);
+    microserviceInstances.setInstancesResponse(findInstancesResponse);
+    microserviceInstances.setRevision("1");
+    microserviceInstances.setNeedRefresh(true);
+  }
+
   private void setup(String microserviceId) {
     createMicroservice(microserviceId);
     createInstance(microserviceId);
+    createMicroserviceInstances();
 
     new MockUp<RegistryUtils>() {
       @Mock
-      List<MicroserviceInstance> findServiceInstance(String appId, String serviceName,
-          String versionRule) {
-        return instances;
+      MicroserviceInstances findServiceInstance(String appId, String serviceName,
+          String versionRule, String revision) {
+        return microserviceInstances;
       }
 
       @Mock
@@ -123,8 +151,8 @@ public class TestMicroserviceVersions {
   public void pullInstancesCancel() {
     new MockUp<RegistryUtils>() {
       @Mock
-      List<MicroserviceInstance> findServiceInstance(String appId, String serviceName,
-          String versionRule) {
+      MicroserviceInstances findServiceInstance(String appId, String serviceName,
+          String versionRule, String revision) {
         throw new Error("must not pull");
       }
     };
@@ -139,8 +167,8 @@ public class TestMicroserviceVersions {
   public void pullInstancesNull() {
     new MockUp<RegistryUtils>() {
       @Mock
-      List<MicroserviceInstance> findServiceInstance(String appId, String serviceName,
-          String versionRule) {
+      MicroserviceInstances findServiceInstance(String appId, String serviceName,
+          String versionRule, String revision) {
         return null;
       }
     };
@@ -169,7 +197,7 @@ public class TestMicroserviceVersions {
     setup(microserviceId);
 
     instances.get(0).setStatus(MicroserviceInstanceStatus.DOWN);
-    Deencapsulation.invoke(microserviceVersions, "setInstances", instances);
+    Deencapsulation.invoke(microserviceVersions, "setInstances", instances, "0");
 
     List<?> resultInstances = Deencapsulation.getField(microserviceVersions, "instances");
     Assert.assertTrue(resultInstances.isEmpty());


### PR DESCRIPTION
…ice center work load

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/SCB) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[SCB-XXX] Fixes bug in ApproximateQuantiles`, where you replace `SCB-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean install` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---
When pull task,SC will return to the result with the version number X-Resource-Revision in the HEADER，SDK recodes this rev and sends it to SC at the next request.
If the rev of SDK is greater than or equal to the rev of SC, it means that  SDK no need to refresh, SC doesn't need to be processed, and returns 304 to indicate that SDK's cache is not refreshed.
If the rev of SDK is less than SC's rev, SC returns the updated result set to SDK, SDK refreshes the cache and updates the Rev.
The effect is that SDK requests different SC and does not have data inconsistencies, at the same time reducing the amount of data transmission in the channel