### PR TITLE
[SCB-264] fix microservice description register problem

### DIFF
--- a/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/api/registry/MicroserviceFactory.java
+++ b/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/api/registry/MicroserviceFactory.java
@@ -56,7 +56,7 @@ public class MicroserviceFactory {
     microservice.setAppId(configuration.getString(CONFIG_APPLICATION_ID_KEY, DEFAULT_APPLICATION_ID));
     microservice.setVersion(configuration.getString(CONFIG_QUALIFIED_MICROSERVICE_VERSION_KEY,
         DEFAULT_MICROSERVICE_VERSION));
-    microservice.setDescription(configuration.getString(CONFIG_QUALIFIED_MICROSERVICE_DESCRIPTION_KEY, ""));
+    setDescription(configuration, microservice);
     microservice.setLevel(configuration.getString(CONFIG_QUALIFIED_MICROSERVICE_ROLE_KEY, "FRONT"));
     microservice.setPaths(ConfigurePropertyUtils.getMicroservicePaths(configuration));
     Map<String, String> propertiesMap = MicroservicePropertiesLoader.INSTANCE.loadProperties(configuration);
@@ -76,6 +76,24 @@ public class MicroserviceFactory {
     microservice.setRegisterBy(CONFIG_DEFAULT_REGISTER_BY);
 
     return microservice;
+  }
+
+  /**
+   * {@code service_description.description} is split by {@code ,},
+   * need to combine the description array to raw description.
+   */
+  private void setDescription(Configuration configuration, Microservice microservice) {
+    String[] descriptionArray = configuration.getStringArray(CONFIG_QUALIFIED_MICROSERVICE_DESCRIPTION_KEY);
+    if (null == descriptionArray || descriptionArray.length < 1) {
+      return;
+    }
+
+    StringBuilder rawDescriptionBuilder = new StringBuilder();
+    for (String desc : descriptionArray) {
+      rawDescriptionBuilder.append(desc).append(",");
+    }
+
+    microservice.setDescription(rawDescriptionBuilder.substring(0, rawDescriptionBuilder.length() - 1));
   }
 
   private boolean allowCrossApp(Map<String, String> propertiesMap) {

--- a/service-registry/src/test/java/org/apache/servicecomb/serviceregistry/api/registry/TestMicroserviceFactory.java
+++ b/service-registry/src/test/java/org/apache/servicecomb/serviceregistry/api/registry/TestMicroserviceFactory.java
@@ -17,15 +17,18 @@
 
 package org.apache.servicecomb.serviceregistry.api.registry;
 
+import static org.apache.servicecomb.foundation.common.base.ServiceCombConstants.CONFIG_QUALIFIED_MICROSERVICE_DESCRIPTION_KEY;
 import static org.apache.servicecomb.serviceregistry.definition.DefinitionConst.CONFIG_ALLOW_CROSS_APP_KEY;
 
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.commons.configuration.Configuration;
 import org.apache.servicecomb.config.archaius.sources.MicroserviceConfigLoader;
 import org.apache.servicecomb.serviceregistry.definition.MicroserviceDefinition;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import mockit.Deencapsulation;
 
@@ -58,5 +61,68 @@ public class TestMicroserviceFactory {
     String microserviceName = "default";
 
     Assert.assertEquals(microserviceName, microservice.getServiceName());
+  }
+
+  @Test
+  public void testSetDescription() {
+    Microservice microservice = new Microservice();
+    MicroserviceFactory factory = new MicroserviceFactory();
+    Configuration configuration = Mockito.mock(Configuration.class);
+
+    Mockito.when(configuration.getStringArray(CONFIG_QUALIFIED_MICROSERVICE_DESCRIPTION_KEY))
+        .thenReturn(new String[] {"test1", "test2"});
+
+    Deencapsulation.invoke(factory, "setDescription", configuration, microservice);
+
+    Assert.assertEquals("test1,test2", microservice.getDescription());
+  }
+
+  @Test
+  public void testSetDescriptionOnNullDescription() {
+    Microservice microservice = new Microservice();
+    MicroserviceFactory factory = new MicroserviceFactory();
+    Configuration configuration = Mockito.mock(Configuration.class);
+
+    Mockito.when(configuration.getStringArray(CONFIG_QUALIFIED_MICROSERVICE_DESCRIPTION_KEY))
+        .thenReturn(null);
+
+    Deencapsulation.invoke(factory, "setDescription", configuration, microservice);
+
+    Assert.assertNull(microservice.getDescription());
+
+    Mockito.when(configuration.getStringArray(CONFIG_QUALIFIED_MICROSERVICE_DESCRIPTION_KEY))
+        .thenReturn(new String[] {});
+
+    Deencapsulation.invoke(factory, "setDescription", configuration, microservice);
+
+    Assert.assertNull(microservice.getDescription());
+  }
+
+  @Test
+  public void testSetDescriptionOnEmptyDescription() {
+    Microservice microservice = new Microservice();
+    MicroserviceFactory factory = new MicroserviceFactory();
+    Configuration configuration = Mockito.mock(Configuration.class);
+
+    Mockito.when(configuration.getStringArray(CONFIG_QUALIFIED_MICROSERVICE_DESCRIPTION_KEY))
+        .thenReturn(new String[] {"", ""});
+
+    Deencapsulation.invoke(factory, "setDescription", configuration, microservice);
+
+    Assert.assertEquals(",", microservice.getDescription());
+  }
+
+  @Test
+  public void testSetDescriptionOnBlankDescription() {
+    Microservice microservice = new Microservice();
+    MicroserviceFactory factory = new MicroserviceFactory();
+    Configuration configuration = Mockito.mock(Configuration.class);
+
+    Mockito.when(configuration.getStringArray(CONFIG_QUALIFIED_MICROSERVICE_DESCRIPTION_KEY))
+        .thenReturn(new String[] {" ", " "});
+
+    Deencapsulation.invoke(factory, "setDescription", configuration, microservice);
+
+    Assert.assertEquals(" , ", microservice.getDescription());
   }
 }


### PR DESCRIPTION
Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/SCB) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Format the pull request title like `[SCB-XXX] Fixes bug in ApproximateQuantiles`, where you replace `SCB-XXX` with the appropriate JIRA issue.
 - [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [ ] Run `mvn clean install` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---

See details in [https://issues.apache.org/jira/browse/SCB-264](https://issues.apache.org/jira/browse/SCB-264).
If the item `service_description.description` in microservice.yaml contains `,`, it will be split into an array and only the first part will be registered to ServiceCenter. 

To avoid this problem, the array should be combined into the raw description.