### PR TITLE
SCB-293 sleep before quering in tracing test

### DIFF
--- a/integration-tests/test-common/src/test/java/org/apache/servicecomb/tests/tracing/TracingTestBase.java
+++ b/integration-tests/test-common/src/test/java/org/apache/servicecomb/tests/tracing/TracingTestBase.java
@@ -75,6 +75,15 @@ public class TracingTestBase {
         .map(this::extractIds)
         .collect(Collectors.toList());
 
+    // Sleep for 5 seconds to wait the reporter finish posting to zipkin server.
+    // See SCB-293
+    try {
+      Thread.sleep(5000);
+    } catch (InterruptedException e) {
+      log.error("Thread interrupted, ", e.getMessage());
+      Thread.currentThread().interrupt();
+    }
+
     String url = zipkin.httpUrl() + "/api/v2/trace/{traceId}";
     log.info("rest url:" + url);
     ResponseEntity<String> responseEntity = restTemplate.getForEntity(url, String.class, traceId(loggedIds));


### PR DESCRIPTION
The zipkin reporter is asynchronous, and there is no gurarantee when
the metrics will be reported to the server. Just sleep for 5 seconds
before quering should be enough for our simple test case scenario.

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/SCB) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[SCB-XXX] Fixes bug in ApproximateQuantiles`, where you replace `SCB-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean install` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---
