### PR TITLE
[SCB-358] fix bug for monitor output id that register only name without any tags

### DIFF
--- a/foundations/foundation-common/src/test/java/org/apache/servicecomb/foundation/common/event/TestEventBus.java
+++ b/foundations/foundation-common/src/test/java/org/apache/servicecomb/foundation/common/event/TestEventBus.java
@@ -23,26 +23,32 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 public class TestEventBus {
 
+  private AtomicBoolean eventReceived = new AtomicBoolean(false);
+
+  private EventListener<String> listener = new EventListener<String>() {
+    @Override
+    public Class<String> getEventClass() {
+      return String.class;
+    }
+
+    @Override
+    public void process(String data) {
+      eventReceived.set(true);
+    }
+  };
+
+  @Before
+  public void reset() {
+    EventBus.getInstance().unregisterEventListener(listener);
+  }
+
   @Test
   public void checkEventReceivedAndProcessed() {
-    AtomicBoolean eventReceived = new AtomicBoolean(false);
-
-    EventListener<String> listener = new EventListener<String>() {
-      @Override
-      public Class<String> getEventClass() {
-        return String.class;
-      }
-
-      @Override
-      public void process(String data) {
-        eventReceived.set(true);
-      }
-    };
-
     EventBus.getInstance().registerEventListener(listener);
 
     EventBus.getInstance().triggerEvent("xxx");
@@ -53,20 +59,6 @@ public class TestEventBus {
 
   @Test
   public void checkEventCanNotReceivedAfterUnregister() throws InterruptedException {
-    AtomicBoolean eventReceived = new AtomicBoolean(false);
-
-    EventListener<String> listener = new EventListener<String>() {
-      @Override
-      public Class<String> getEventClass() {
-        return String.class;
-      }
-
-      @Override
-      public void process(String data) {
-        eventReceived.set(true);
-      }
-    };
-
     EventBus.getInstance().registerEventListener(listener);
 
     EventBus.getInstance().triggerEvent("xxx");
@@ -84,20 +76,6 @@ public class TestEventBus {
 
   @Test
   public void checkUnmatchTypeWillNotReceived() throws InterruptedException {
-    AtomicBoolean eventReceived = new AtomicBoolean(false);
-
-    EventListener<String> listener = new EventListener<String>() {
-      @Override
-      public Class<String> getEventClass() {
-        return String.class;
-      }
-
-      @Override
-      public void process(String data) {
-        eventReceived.set(true);
-      }
-    };
-
     EventBus.getInstance().registerEventListener(listener);
 
     //trigger a Integer type event object

--- a/foundations/foundation-common/src/test/java/org/apache/servicecomb/foundation/common/event/TestEventBus.java
+++ b/foundations/foundation-common/src/test/java/org/apache/servicecomb/foundation/common/event/TestEventBus.java
@@ -81,4 +81,28 @@ public class TestEventBus {
     Thread.sleep(1000);
     Assert.assertFalse(eventReceived.get());
   }
+
+  @Test
+  public void checkUnmatchTypeWillNotReceived() throws InterruptedException {
+    AtomicBoolean eventReceived = new AtomicBoolean(false);
+
+    EventListener<String> listener = new EventListener<String>() {
+      @Override
+      public Class<String> getEventClass() {
+        return String.class;
+      }
+
+      @Override
+      public void process(String data) {
+        eventReceived.set(true);
+      }
+    };
+
+    EventBus.getInstance().registerEventListener(listener);
+
+    //trigger a Integer type event object
+    EventBus.getInstance().triggerEvent(new Integer(1));
+    Thread.sleep(1000);
+    Assert.assertFalse(eventReceived.get());
+  }
 }

--- a/foundations/foundation-common/src/test/java/org/apache/servicecomb/foundation/common/event/TestEventBus.java
+++ b/foundations/foundation-common/src/test/java/org/apache/servicecomb/foundation/common/event/TestEventBus.java
@@ -58,7 +58,7 @@ public class TestEventBus {
   }
 
   @Test
-  public void checkEventCanNotReceivedAfterUnregister() throws InterruptedException {
+  public void checkEventCanNotReceivedAfterUnregister() {
     EventBus.getInstance().registerEventListener(listener);
 
     EventBus.getInstance().triggerEvent("xxx");
@@ -70,17 +70,15 @@ public class TestEventBus {
 
     EventBus.getInstance().unregisterEventListener(listener);
     EventBus.getInstance().triggerEvent("xxx");
-    Thread.sleep(1000);
     Assert.assertFalse(eventReceived.get());
   }
 
   @Test
-  public void checkUnmatchTypeWillNotReceived() throws InterruptedException {
+  public void checkUnmatchTypeWillNotReceived() {
     EventBus.getInstance().registerEventListener(listener);
 
     //trigger a Integer type event object
     EventBus.getInstance().triggerEvent(new Integer(1));
-    Thread.sleep(1000);
     Assert.assertFalse(eventReceived.get());
   }
 }

--- a/foundations/foundation-metrics/src/main/java/org/apache/servicecomb/foundation/metrics/publish/Metric.java
+++ b/foundations/foundation-metrics/src/main/java/org/apache/servicecomb/foundation/metrics/publish/Metric.java
@@ -37,9 +37,11 @@ public class Metric {
   public Metric(String id, double value) {
     String[] nameAndTag = id.split("\\(");
     this.tags = new HashMap<>();
-    String[] tagAnValues = nameAndTag[1].split("[=,)]");
-    for (int i = 0; i < tagAnValues.length; i += 2) {
-      this.tags.put(tagAnValues[i], tagAnValues[i + 1]);
+    if (nameAndTag.length > 1) {
+      String[] tagAnValues = nameAndTag[1].split("[=,)]");
+      for (int i = 0; i < tagAnValues.length; i += 2) {
+        this.tags.put(tagAnValues[i], tagAnValues[i + 1]);
+      }
     }
     this.name = nameAndTag[0];
     this.value = value;

--- a/foundations/foundation-metrics/src/main/java/org/apache/servicecomb/foundation/metrics/publish/Metric.java
+++ b/foundations/foundation-metrics/src/main/java/org/apache/servicecomb/foundation/metrics/publish/Metric.java
@@ -36,7 +36,7 @@ public class Metric {
   }
 
   public Metric(String id, double value) {
-    if (isCorrectId(id)) {
+    if (validateMetricId(id)) {
       this.tags = new HashMap<>();
       this.value = value;
       String[] nameAndTag = id.split("[()]");
@@ -44,7 +44,7 @@ public class Metric {
         if (!id.endsWith(")")) {
           this.name = nameAndTag[0];
         } else {
-          throw new ServiceCombException("bad format id");
+          throw new ServiceCombException("bad format id " + id);
         }
       } else if (nameAndTag.length == 2) {
         this.name = nameAndTag[0];
@@ -54,14 +54,14 @@ public class Metric {
           if (kv.length == 2) {
             this.tags.put(kv[0], kv[1]);
           } else {
-            throw new ServiceCombException("bad format tag");
+            throw new ServiceCombException("bad format tag " + id);
           }
         }
       } else {
-        throw new ServiceCombException("bad format id");
+        throw new ServiceCombException("bad format id " + id);
       }
     } else {
-      throw new ServiceCombException("bad format id");
+      throw new ServiceCombException("bad format id " + id);
     }
   }
 
@@ -103,7 +103,7 @@ public class Metric {
       }
       return true;
     }
-    throw new ServiceCombException("bad tags count");
+    throw new ServiceCombException("bad tags count : " + String.join(",", tags));
   }
 
   private int getCharCount(String id, char c) {
@@ -116,7 +116,8 @@ public class Metric {
     return count;
   }
 
-  private boolean isCorrectId(String id) {
-    return id != null && !id.endsWith("(") && getCharCount(id, '(') <= 1 && getCharCount(id, ')') <= 1;
+  private boolean validateMetricId(String id) {
+    return id != null && !"".equals(id) && !id.endsWith("(") &&
+        getCharCount(id, '(') <= 1 && getCharCount(id, ')') <= 1;
   }
 }

--- a/foundations/foundation-metrics/src/main/java/org/apache/servicecomb/foundation/metrics/publish/Metric.java
+++ b/foundations/foundation-metrics/src/main/java/org/apache/servicecomb/foundation/metrics/publish/Metric.java
@@ -25,9 +25,9 @@ import org.apache.servicecomb.foundation.common.exceptions.ServiceCombException;
 import org.apache.servicecomb.foundation.metrics.MetricsConst;
 
 public class Metric {
-  private final String name;
+  private String name;
 
-  private final Map<String, String> tags;
+  private Map<String, String> tags;
 
   private double value;
 
@@ -41,27 +41,35 @@ public class Metric {
       this.value = value;
       String[] nameAndTag = id.split("[()]");
       if (nameAndTag.length == 1) {
-        if (!id.endsWith(")")) {
-          this.name = nameAndTag[0];
-        } else {
-          throw new ServiceCombException("bad format id " + id);
-        }
+        processIdWithoutTags(id, nameAndTag[0]);
       } else if (nameAndTag.length == 2) {
-        this.name = nameAndTag[0];
-        String[] tagAnValues = nameAndTag[1].split(",");
-        for (String tagAnValue : tagAnValues) {
-          String[] kv = tagAnValue.split("=");
-          if (kv.length == 2) {
-            this.tags.put(kv[0], kv[1]);
-          } else {
-            throw new ServiceCombException("bad format tag " + id);
-          }
-        }
+        processIdHadTags(id, nameAndTag);
       } else {
         throw new ServiceCombException("bad format id " + id);
       }
     } else {
       throw new ServiceCombException("bad format id " + id);
+    }
+  }
+
+  private void processIdWithoutTags(String id, String name) {
+    if (!id.endsWith(")")) {
+      this.name = name;
+    } else {
+      throw new ServiceCombException("bad format id " + id);
+    }
+  }
+
+  private void processIdHadTags(String id, String[] nameAndTag) {
+    this.name = nameAndTag[0];
+    String[] tagAnValues = nameAndTag[1].split(",");
+    for (String tagAnValue : tagAnValues) {
+      String[] kv = tagAnValue.split("=");
+      if (kv.length == 2) {
+        this.tags.put(kv[0], kv[1]);
+      } else {
+        throw new ServiceCombException("bad format tag " + id);
+      }
     }
   }
 

--- a/foundations/foundation-metrics/src/test/java/org/apache/servicecomb/foundation/metrics/health/TestHealthCheckerManager.java
+++ b/foundations/foundation-metrics/src/test/java/org/apache/servicecomb/foundation/metrics/health/TestHealthCheckerManager.java
@@ -20,6 +20,7 @@ package org.apache.servicecomb.foundation.metrics.health;
 import java.util.Map;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 public class TestHealthCheckerManager {
@@ -48,32 +49,35 @@ public class TestHealthCheckerManager {
     }
   };
 
-  private void reset() {
+  @Before
+  public void reset() {
     HealthCheckerManager.getInstance().unregister(good.getName());
     HealthCheckerManager.getInstance().unregister(bad.getName());
   }
 
   @Test
-  public void checkResultCount() {
-    reset();
+  public void checkResultCount_None() {
     Map<String, HealthCheckResult> results = HealthCheckerManager.getInstance().check();
     Assert.assertEquals(0, results.size());
+  }
 
-    reset();
+  @Test
+  public void checkResultCount_One() {
     HealthCheckerManager.getInstance().register(good);
-    results = HealthCheckerManager.getInstance().check();
+    Map<String, HealthCheckResult> results = HealthCheckerManager.getInstance().check();
     Assert.assertEquals(1, results.size());
+  }
 
-    reset();
+  @Test
+  public void checkResultCount_Both() {
     HealthCheckerManager.getInstance().register(good);
     HealthCheckerManager.getInstance().register(bad);
-    results = HealthCheckerManager.getInstance().check();
+    Map<String, HealthCheckResult> results = HealthCheckerManager.getInstance().check();
     Assert.assertEquals(2, results.size());
   }
 
   @Test
   public void checkGoodResult() {
-    reset();
     HealthCheckerManager.getInstance().register(good);
     HealthCheckerManager.getInstance().register(bad);
     HealthCheckResult result = HealthCheckerManager.getInstance().check().get("testGood");
@@ -84,7 +88,6 @@ public class TestHealthCheckerManager {
 
   @Test
   public void checkBadResult() {
-    reset();
     HealthCheckerManager.getInstance().register(good);
     HealthCheckerManager.getInstance().register(bad);
     HealthCheckResult result = HealthCheckerManager.getInstance().check().get("testBad");

--- a/foundations/foundation-metrics/src/test/java/org/apache/servicecomb/foundation/metrics/publish/TestMetric.java
+++ b/foundations/foundation-metrics/src/test/java/org/apache/servicecomb/foundation/metrics/publish/TestMetric.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.servicecomb.foundation.metrics.publish;
+
+import org.apache.servicecomb.foundation.common.exceptions.ServiceCombException;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestMetric {
+
+  @Test
+  public void testNewMetric() throws Exception {
+
+    Metric metric = new Metric("Key", 100);
+    Assert.assertEquals(0, metric.getTagsCount());
+
+    metric = new Metric("Key(A=1)", 100);
+    Assert.assertEquals(1, metric.getTagsCount());
+    Assert.assertEquals(true, metric.containsTagKey("A"));
+
+    metric = new Metric("Key(A=1,B=X)", 100);
+    Assert.assertEquals(2, metric.getTagsCount());
+    Assert.assertEquals(true, metric.containsTagKey("A"));
+    Assert.assertEquals(true, metric.containsTagKey("B"));
+    Assert.assertEquals("1", metric.getTagValue("A"));
+    Assert.assertEquals("X", metric.getTagValue("B"));
+
+    checkBadIdFormat("Key(");
+    checkBadIdFormat("Key)");
+    checkBadIdFormat("Key()");
+
+    checkBadIdFormat("Key(X)");
+    checkBadIdFormat("Key(X");
+    checkBadIdFormat("Key(X))");
+    checkBadIdFormat("Key((X)");
+
+    checkBadIdFormat("Key(X=)");
+    checkBadIdFormat("Key(X=");
+    checkBadIdFormat("Key(X=))");
+    checkBadIdFormat("Key((X=)");
+
+    checkBadIdFormat("Key(X=,)");
+    checkBadIdFormat("Key(X=,");
+    checkBadIdFormat("Key(X=,))");
+    checkBadIdFormat("Key((X=,)");
+
+    checkBadIdFormat("Key(X=,Y)");
+    checkBadIdFormat("Key(X=,Y");
+    checkBadIdFormat("Key(X=,Y))");
+    checkBadIdFormat("Key((X=,Y)");
+
+    checkBadIdFormat("Key(X=1,Y)");
+    checkBadIdFormat("Key(X=1,Y");
+    checkBadIdFormat("Key(X=1,Y))");
+    checkBadIdFormat("Key((X=1,Y)");
+
+    checkBadIdFormat("Key(X=1))");
+    checkBadIdFormat("Key((X=1)");
+
+    checkBadIdFormat("Key(X=1) ");
+    checkBadIdFormat("Key(X=1,Y=2)Z");
+
+    checkBadIdFormat("Key(X=1)()");
+    checkBadIdFormat("Key(X=1)(Y=1)");
+  }
+
+  @Test
+  public void checkMetricContainsTag() throws Exception {
+    Metric metric = new Metric("Key(A=1,B=X)", 100);
+    Assert.assertEquals(true, metric.containsTag("A", "1"));
+
+    try {
+      metric.containsTag("A");
+      throw new Exception("CheckFailed");
+    }
+    //ignore because throw exception is correct
+    catch (ServiceCombException ignore) {
+    }
+
+    try {
+      metric.containsTag("A", "1", "B");
+      throw new Exception("CheckFailed");
+    }
+    //ignore because throw exception is correct
+    catch (ServiceCombException ignore) {
+    }
+
+    try {
+      metric.containsTag("A", "1", "B", "X", "C");
+      throw new Exception("CheckFailed");
+    }
+    //ignore because throw exception is correct
+    catch (ServiceCombException ignore) {
+    }
+  }
+
+  private void checkBadIdFormat(String id) throws Exception {
+    try {
+      new Metric(id, 100);
+      throw new Exception("CheckFailed");
+    }
+    //ignore because throw exception is correct
+    catch (ServiceCombException ignore) {
+    }
+  }
+}

--- a/foundations/foundation-metrics/src/test/java/org/apache/servicecomb/foundation/metrics/publish/TestMetricNode.java
+++ b/foundations/foundation-metrics/src/test/java/org/apache/servicecomb/foundation/metrics/publish/TestMetricNode.java
@@ -17,7 +17,9 @@
 
 package org.apache.servicecomb.foundation.metrics.publish;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
@@ -86,5 +88,22 @@ public class TestMetricNode {
     MetricNode node_k1 = node.getChildrenNode("1");
     MetricNode newNode = new MetricNode(node_k1.getMetrics(), "K2", "K3");
     Assert.assertEquals(1, newNode.getChildrenNode("2").getChildrenNode("3").getMetricCount(), 0);
+  }
+
+  @Test
+  public void testNewMetricNode() {
+    List<Metric> metrics = new ArrayList<>();
+    metrics.add(new Metric("Y(K1=1,K2=2,K3=3)", 1));
+    metrics.add(new Metric("Y(K1=1,K2=20,K3=30)", 10));
+    metrics.add(new Metric("Y(K1=10,K2=20,K3=300)", 100));
+    metrics.add(new Metric("Y(K1=10,K2=20,K3=3000)", 1000));
+
+    MetricNode node = new MetricNode(metrics);
+    Assert.assertEquals(4, node.getMetricCount());
+    Assert.assertEquals(1.0, node.getFirstMatchMetricValue("K3", "3"), 0);
+
+    node = new MetricNode(metrics, "K1");
+    Assert.assertEquals(2, node.getChildrenCount());
+    Assert.assertEquals(1.0, node.getChildren("1").getFirstMatchMetricValue("K3", "3"), 0);
   }
 }

--- a/foundations/foundation-metrics/src/test/java/org/apache/servicecomb/foundation/metrics/publish/TestMetricsLoader.java
+++ b/foundations/foundation-metrics/src/test/java/org/apache/servicecomb/foundation/metrics/publish/TestMetricsLoader.java
@@ -23,7 +23,9 @@ import java.util.Map;
 import org.apache.servicecomb.foundation.common.exceptions.ServiceCombException;
 import org.junit.Assert;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 public class TestMetricsLoader {
   private static MetricsLoader loader;
@@ -55,14 +57,13 @@ public class TestMetricsLoader {
     Assert.assertEquals(2, node.getChildrenCount());
   }
 
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
   @Test
-  public void checkNoSuchId() throws Exception {
-    try {
-      loader.getMetricTree("Z");
-      throw new Exception("CheckFailed");
-    }
-    //ignore because throw exception is correct
-    catch (ServiceCombException ignore) {
-    }
+  public void checkNoSuchId() {
+    thrown.expect(ServiceCombException.class);
+    loader.getMetricTree("Z");
+    Assert.fail("checkNoSuchId failed");
   }
 }

--- a/foundations/foundation-metrics/src/test/java/org/apache/servicecomb/foundation/metrics/publish/TestMetricsLoader.java
+++ b/foundations/foundation-metrics/src/test/java/org/apache/servicecomb/foundation/metrics/publish/TestMetricsLoader.java
@@ -20,6 +20,7 @@ package org.apache.servicecomb.foundation.metrics.publish;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.servicecomb.foundation.common.exceptions.ServiceCombException;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -52,5 +53,16 @@ public class TestMetricsLoader {
   public void checkGetChildrenCount() {
     MetricNode node = loader.getMetricTree("X", "K1");
     Assert.assertEquals(2, node.getChildrenCount());
+  }
+
+  @Test
+  public void checkNoSuchId() throws Exception {
+    try {
+      loader.getMetricTree("Z");
+      throw new Exception("CheckFailed");
+    }
+    //ignore because throw exception is correct
+    catch (ServiceCombException ignore) {
+    }
   }
 }

--- a/metrics/metrics-core/src/main/java/org/apache/servicecomb/metrics/core/MonitorManager.java
+++ b/metrics/metrics-core/src/main/java/org/apache/servicecomb/metrics/core/MonitorManager.java
@@ -82,7 +82,7 @@ public class MonitorManager {
   }
 
   public Counter getCounter(String name, String... tags) {
-    if (checkMonitorNameAndTags(name, tags)) {
+    if (isCorrectMonitorNameAndTags(name, tags)) {
       return counters.computeIfAbsent(getMonitorKey(name, tags), f -> {
         Counter counter = new BasicCounter(getConfig(name, tags));
         basicMonitorRegistry.register(counter);
@@ -93,7 +93,7 @@ public class MonitorManager {
   }
 
   public Counter getCounter(Function<MonitorConfig, Counter> function, String name, String... tags) {
-    if (checkMonitorNameAndTags(name, tags)) {
+    if (isCorrectMonitorNameAndTags(name, tags)) {
       return counters.computeIfAbsent(getMonitorKey(name, tags), f -> {
         Counter counter = function.apply(getConfig(name, tags));
         basicMonitorRegistry.register(counter);
@@ -104,7 +104,7 @@ public class MonitorManager {
   }
 
   public MaxGauge getMaxGauge(String name, String... tags) {
-    if (checkMonitorNameAndTags(name, tags)) {
+    if (isCorrectMonitorNameAndTags(name, tags)) {
       return maxGauges.computeIfAbsent(getMonitorKey(name, tags), f -> {
         MaxGauge maxGauge = new MaxGauge(getConfig(name, tags));
         basicMonitorRegistry.register(maxGauge);
@@ -115,7 +115,7 @@ public class MonitorManager {
   }
 
   public <V extends Number> Gauge getGauge(Callable<V> callable, String name, String... tags) {
-    if (checkMonitorNameAndTags(name, tags)) {
+    if (isCorrectMonitorNameAndTags(name, tags)) {
       return gauges.computeIfAbsent(getMonitorKey(name, tags), f -> {
         Gauge gauge = new BasicGauge<>(getConfig(name, tags), callable);
         basicMonitorRegistry.register(gauge);
@@ -126,7 +126,7 @@ public class MonitorManager {
   }
 
   public Timer getTimer(String name, String... tags) {
-    if (checkMonitorNameAndTags(name, tags)) {
+    if (isCorrectMonitorNameAndTags(name, tags)) {
       return timers.computeIfAbsent(getMonitorKey(name, tags), f -> {
         Timer timer = new BasicTimer(getConfig(name, tags));
         basicMonitorRegistry.register(timer);
@@ -146,7 +146,7 @@ public class MonitorManager {
   }
 
   private MonitorConfig getConfig(String name, String... tags) {
-    if (checkMonitorNameAndTags(name, tags)) {
+    if (isCorrectMonitorNameAndTags(name, tags)) {
       Builder builder = MonitorConfig.builder(name);
       for (int i = 0; i < tags.length; i += 2) {
         builder.withTag(tags[i], tags[i + 1]);
@@ -157,7 +157,7 @@ public class MonitorManager {
   }
 
   private String getMonitorKey(String name, String... tags) {
-    if (checkMonitorNameAndTags(name, tags)) {
+    if (isCorrectMonitorNameAndTags(name, tags)) {
       if (tags.length != 0) {
         SortedMap<String, String> tagMap = new TreeMap<>();
         for (int i = 0; i < tags.length; i += 2) {
@@ -207,7 +207,7 @@ public class MonitorManager {
     this.getGauge(callable, MetricsConst.JVM, MetricsConst.TAG_STATISTIC, "gauge", MetricsConst.TAG_NAME, name);
   }
 
-  private boolean checkMonitorNameAndTags(String name, String... tags) {
+  private boolean isCorrectMonitorNameAndTags(String name, String... tags) {
     return StringUtils.isNotEmpty(name) && tags.length % 2 == 0;
   }
 }

--- a/metrics/metrics-core/src/main/java/org/apache/servicecomb/metrics/core/MonitorManager.java
+++ b/metrics/metrics-core/src/main/java/org/apache/servicecomb/metrics/core/MonitorManager.java
@@ -159,9 +159,12 @@ public class MonitorManager {
         tagPart.append(String.format("%s=%s,", tag.getKey(), tag.getValue()));
       }
     }
-    tagPart.deleteCharAt(tagPart.length() - 1);
-    tagPart.append(")");
-    return config.getName() + tagPart.toString();
+    if (tagPart.length() != 1) {
+      tagPart.deleteCharAt(tagPart.length() - 1);
+      tagPart.append(")");
+      return config.getName() + tagPart.toString();
+    }
+    return config.getName();
   }
 
 

--- a/metrics/metrics-core/src/main/java/org/apache/servicecomb/metrics/core/MonitorManager.java
+++ b/metrics/metrics-core/src/main/java/org/apache/servicecomb/metrics/core/MonitorManager.java
@@ -60,6 +60,8 @@ public class MonitorManager {
 
   private final MonitorRegistry basicMonitorRegistry;
 
+  private static final char[] forbiddenCharacter = new char[] {'(', ')', '=', ','};
+
   private static final MonitorManager INSTANCE = new MonitorManager();
 
   public static MonitorManager getInstance() {
@@ -208,6 +210,17 @@ public class MonitorManager {
   }
 
   private boolean isCorrectMonitorNameAndTags(String name, String... tags) {
-    return StringUtils.isNotEmpty(name) && tags.length % 2 == 0;
+    boolean passed = StringUtils.isNotEmpty(name) && tags.length % 2 == 0;
+    if (passed) {
+      if (StringUtils.containsNone(name, forbiddenCharacter)) {
+        for (String tag : tags) {
+          if (StringUtils.containsAny(tag, forbiddenCharacter)) {
+            return false;
+          }
+        }
+        return true;
+      }
+    }
+    return false;
   }
 }

--- a/metrics/metrics-core/src/test/java/org/apache/servicecomb/metrics/core/TestHealthCheckerPublisher.java
+++ b/metrics/metrics-core/src/test/java/org/apache/servicecomb/metrics/core/TestHealthCheckerPublisher.java
@@ -24,6 +24,7 @@ import org.apache.servicecomb.foundation.metrics.health.HealthChecker;
 import org.apache.servicecomb.foundation.metrics.health.HealthCheckerManager;
 import org.apache.servicecomb.metrics.core.publish.HealthCheckerPublisher;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 public class TestHealthCheckerPublisher {
@@ -52,14 +53,14 @@ public class TestHealthCheckerPublisher {
   };
 
 
-  private void reset() {
+  @Before
+  public void reset() {
     HealthCheckerManager.getInstance().unregister(good.getName());
     HealthCheckerManager.getInstance().unregister(bad.getName());
   }
 
   @Test
   public void checkHealthGood() {
-    reset();
     HealthCheckerManager.getInstance().register(good);
     HealthCheckerPublisher publisher = new HealthCheckerPublisher();
     Assert.assertEquals(true, publisher.checkHealth());
@@ -67,7 +68,6 @@ public class TestHealthCheckerPublisher {
 
   @Test
   public void checkHealthBad() {
-    reset();
     HealthCheckerManager.getInstance().register(good);
     HealthCheckerManager.getInstance().register(bad);
     HealthCheckerPublisher publisher = new HealthCheckerPublisher();
@@ -76,7 +76,6 @@ public class TestHealthCheckerPublisher {
 
   @Test
   public void checkHealthDetails() {
-    reset();
     HealthCheckerManager.getInstance().register(good);
     HealthCheckerManager.getInstance().register(bad);
     HealthCheckerPublisher publisher = new HealthCheckerPublisher();

--- a/metrics/metrics-core/src/test/java/org/apache/servicecomb/metrics/core/TestHealthCheckerPublisher.java
+++ b/metrics/metrics-core/src/test/java/org/apache/servicecomb/metrics/core/TestHealthCheckerPublisher.java
@@ -24,46 +24,61 @@ import org.apache.servicecomb.foundation.metrics.health.HealthChecker;
 import org.apache.servicecomb.foundation.metrics.health.HealthCheckerManager;
 import org.apache.servicecomb.metrics.core.publish.HealthCheckerPublisher;
 import org.junit.Assert;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class TestHealthCheckerPublisher {
+  private HealthChecker good = new HealthChecker() {
+    @Override
+    public String getName() {
+      return "test";
+    }
 
-  @BeforeClass
-  public static void setup() {
-    HealthCheckerManager.getInstance().register(new HealthChecker() {
-      @Override
-      public String getName() {
-        return "test";
-      }
+    @Override
+    public HealthCheckResult check() {
+      return new HealthCheckResult(true, "info", "extra data");
+    }
+  };
 
-      @Override
-      public HealthCheckResult check() {
-        return new HealthCheckResult(true, "info", "extra data");
-      }
-    });
+  private HealthChecker bad = new HealthChecker() {
+    @Override
+    public String getName() {
+      return "test2";
+    }
 
-    HealthCheckerManager.getInstance().register(new HealthChecker() {
-      @Override
-      public String getName() {
-        return "test2";
-      }
+    @Override
+    public HealthCheckResult check() {
+      return new HealthCheckResult(false, "info2", "extra data 2");
+    }
+  };
 
-      @Override
-      public HealthCheckResult check() {
-        return new HealthCheckResult(false, "info2", "extra data 2");
-      }
-    });
+
+  private void reset() {
+    HealthCheckerManager.getInstance().unregister(good.getName());
+    HealthCheckerManager.getInstance().unregister(bad.getName());
   }
 
   @Test
-  public void checkHealth() {
+  public void checkHealthGood() {
+    reset();
+    HealthCheckerManager.getInstance().register(good);
+    HealthCheckerPublisher publisher = new HealthCheckerPublisher();
+    Assert.assertEquals(true, publisher.checkHealth());
+  }
+
+  @Test
+  public void checkHealthBad() {
+    reset();
+    HealthCheckerManager.getInstance().register(good);
+    HealthCheckerManager.getInstance().register(bad);
     HealthCheckerPublisher publisher = new HealthCheckerPublisher();
     Assert.assertEquals(false, publisher.checkHealth());
   }
 
   @Test
   public void checkHealthDetails() {
+    reset();
+    HealthCheckerManager.getInstance().register(good);
+    HealthCheckerManager.getInstance().register(bad);
     HealthCheckerPublisher publisher = new HealthCheckerPublisher();
     Map<String, HealthCheckResult> content = publisher.checkHealthDetails();
     Assert.assertEquals(true, content.get("test").isHealthy());

--- a/metrics/metrics-core/src/test/java/org/apache/servicecomb/metrics/core/TestMonitorManager.java
+++ b/metrics/metrics-core/src/test/java/org/apache/servicecomb/metrics/core/TestMonitorManager.java
@@ -31,7 +31,9 @@ import org.apache.servicecomb.foundation.metrics.publish.MetricsLoader;
 import org.apache.servicecomb.swagger.invocation.InvocationType;
 import org.junit.Assert;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import com.netflix.servo.monitor.Counter;
 
@@ -274,51 +276,46 @@ public class TestMonitorManager {
     Assert.assertEquals(999, MonitorManager.getInstance().measure().get("MonitorWithoutAnyTag"), 0);
   }
 
-  @Test
-  public void checkRegisterMonitorWithBadTags() throws Exception {
-    MonitorManager.getInstance().getCounter("Monitor", "X", "Y");
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
 
-    try {
-      MonitorManager.getInstance().getCounter("MonitorWithBadCountTag", "X");
-      throw new Exception("CheckFailed");
-    }
-    //ignore because throw exception is correct
-    catch (ServiceCombException ignore) {
-    }
+  @Test
+  public void checkRegisterMonitor() {
+    MonitorManager.getInstance().getCounter("Monitor", "X", "Y");
   }
 
   @Test
-  public void checkRegisterMonitorWithBadNameAndTags() throws Exception {
-    try {
-      MonitorManager.getInstance().getCounter("MonitorWithBad(");
-      throw new Exception("CheckFailed");
-    }
-    //ignore because throw exception is correct
-    catch (ServiceCombException ignore) {
-    }
+  public void checkRegisterMonitorWithBadTags() {
+    thrown.expect(ServiceCombException.class);
+    MonitorManager.getInstance().getCounter("MonitorWithBadCountTag", "X");
+    Assert.fail("checkRegisterMonitorWithBadTags failed");
+  }
 
-    try {
-      MonitorManager.getInstance().getCounter("MonitorWithBad,");
-      throw new Exception("CheckFailed");
-    }
-    //ignore because throw exception is correct
-    catch (ServiceCombException ignore) {
-    }
+  @Test
+  public void checkRegisterMonitorWithBadNameAndTags_ContainLeftParenthesisChar() {
+    thrown.expect(ServiceCombException.class);
+    MonitorManager.getInstance().getCounter("MonitorWithBad(");
+    Assert.fail("checkRegisterMonitorWithBadTags failed : MonitorWithBad(");
+  }
 
-    try {
-      MonitorManager.getInstance().getCounter("MonitorWithBad","TagX=","Y");
-      throw new Exception("CheckFailed");
-    }
-    //ignore because throw exception is correct
-    catch (ServiceCombException ignore) {
-    }
+  @Test
+  public void checkRegisterMonitorWithBadNameAndTags_ContainCommaChar() {
+    thrown.expect(ServiceCombException.class);
+    MonitorManager.getInstance().getCounter("MonitorWithBad,");
+    Assert.fail("checkRegisterMonitorWithBadTags failed : MonitorWithBad,");
+  }
 
-    try {
-      MonitorManager.getInstance().getCounter("MonitorWithBad","TagX","Y)");
-      throw new Exception("CheckFailed");
-    }
-    //ignore because throw exception is correct
-    catch (ServiceCombException ignore) {
-    }
+  @Test
+  public void checkRegisterMonitorWithBadNameAndTags_ContainEqualChar() {
+    thrown.expect(ServiceCombException.class);
+    MonitorManager.getInstance().getCounter("MonitorWithBad", "TagX=", "Y");
+    Assert.fail("checkRegisterMonitorWithBadTags failed : name = MonitorWithBad, tags = TagX=,Y");
+  }
+
+  @Test
+  public void checkRegisterMonitorWithBadNameAndTags_ContainRightParenthesisChar() {
+    thrown.expect(ServiceCombException.class);
+    MonitorManager.getInstance().getCounter("MonitorWithBad", "TagX", "Y)");
+    Assert.fail("checkRegisterMonitorWithBadTags failed : name = MonitorWithBad, tags = TagX,Y)");
   }
 }

--- a/metrics/metrics-core/src/test/java/org/apache/servicecomb/metrics/core/TestMonitorManager.java
+++ b/metrics/metrics-core/src/test/java/org/apache/servicecomb/metrics/core/TestMonitorManager.java
@@ -32,6 +32,8 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import com.netflix.servo.monitor.Counter;
+
 public class TestMonitorManager {
 
   private static MetricsLoader currentWindowMetricsLoader;
@@ -261,5 +263,16 @@ public class TestMonitorManager {
         .getChildrenNode(String.valueOf(InvocationType.PRODUCER).toLowerCase())
         .getChildrenNode(MetricsConst.STAGE_QUEUE);
     Assert.assertEquals(1, node4_queue.getMatchStatisticMetricValue("waitInQueue"), 0);
+  }
+
+  @Test
+  public void checkRegisterMonitorWithoutAnyTags() {
+    Counter counter = MonitorManager.getInstance().getCounter("MonitorWithoutAnyTag");
+    counter.increment(999);
+    MetricsLoader loader = new MetricsLoader(MonitorManager.getInstance().measure());
+
+    MetricNode node = loader.getMetricTree("MonitorWithoutAnyTag");
+    Assert.assertEquals(1, node.getMetricCount());
+    Assert.assertEquals(999, node.getMetrics().iterator().next().getValue(), 0);
   }
 }

--- a/metrics/metrics-core/src/test/java/org/apache/servicecomb/metrics/core/TestMonitorManager.java
+++ b/metrics/metrics-core/src/test/java/org/apache/servicecomb/metrics/core/TestMonitorManager.java
@@ -24,6 +24,7 @@ import org.apache.servicecomb.core.metrics.InvocationFinishedEvent;
 import org.apache.servicecomb.core.metrics.InvocationStartExecutionEvent;
 import org.apache.servicecomb.core.metrics.InvocationStartedEvent;
 import org.apache.servicecomb.foundation.common.event.EventBus;
+import org.apache.servicecomb.foundation.common.exceptions.ServiceCombException;
 import org.apache.servicecomb.foundation.metrics.MetricsConst;
 import org.apache.servicecomb.foundation.metrics.publish.MetricNode;
 import org.apache.servicecomb.foundation.metrics.publish.MetricsLoader;
@@ -269,10 +270,20 @@ public class TestMonitorManager {
   public void checkRegisterMonitorWithoutAnyTags() {
     Counter counter = MonitorManager.getInstance().getCounter("MonitorWithoutAnyTag");
     counter.increment(999);
-    MetricsLoader loader = new MetricsLoader(MonitorManager.getInstance().measure());
+    Assert.assertTrue(MonitorManager.getInstance().measure().containsKey("MonitorWithoutAnyTag"));
+    Assert.assertEquals(999, MonitorManager.getInstance().measure().get("MonitorWithoutAnyTag"), 0);
+  }
 
-    MetricNode node = loader.getMetricTree("MonitorWithoutAnyTag");
-    Assert.assertEquals(1, node.getMetricCount());
-    Assert.assertEquals(999, node.getMetrics().iterator().next().getValue(), 0);
+  @Test
+  public void checkRegisterMonitorWithBadTags() throws Exception {
+    MonitorManager.getInstance().getCounter("Monitor", "X", "Y");
+
+    try {
+      MonitorManager.getInstance().getCounter("MonitorWithBadCountTag", "X");
+      throw new Exception("CheckFailed");
+    }
+    //ignore because throw exception is correct
+    catch (ServiceCombException ignore) {
+    }
   }
 }

--- a/metrics/metrics-core/src/test/java/org/apache/servicecomb/metrics/core/TestMonitorManager.java
+++ b/metrics/metrics-core/src/test/java/org/apache/servicecomb/metrics/core/TestMonitorManager.java
@@ -286,4 +286,39 @@ public class TestMonitorManager {
     catch (ServiceCombException ignore) {
     }
   }
+
+  @Test
+  public void checkRegisterMonitorWithBadNameAndTags() throws Exception {
+    try {
+      MonitorManager.getInstance().getCounter("MonitorWithBad(");
+      throw new Exception("CheckFailed");
+    }
+    //ignore because throw exception is correct
+    catch (ServiceCombException ignore) {
+    }
+
+    try {
+      MonitorManager.getInstance().getCounter("MonitorWithBad,");
+      throw new Exception("CheckFailed");
+    }
+    //ignore because throw exception is correct
+    catch (ServiceCombException ignore) {
+    }
+
+    try {
+      MonitorManager.getInstance().getCounter("MonitorWithBad","TagX=","Y");
+      throw new Exception("CheckFailed");
+    }
+    //ignore because throw exception is correct
+    catch (ServiceCombException ignore) {
+    }
+
+    try {
+      MonitorManager.getInstance().getCounter("MonitorWithBad","TagX","Y)");
+      throw new Exception("CheckFailed");
+    }
+    //ignore because throw exception is correct
+    catch (ServiceCombException ignore) {
+    }
+  }
 }


### PR DESCRIPTION
Signed-off-by: zhengyangyong <yangyong.zheng@huawei.com>

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/SCB) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[SCB-XXX] Fixes bug in ApproximateQuantiles`, where you replace `SCB-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean install` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---
User can register monitor only name without any tags like :
*MonitorManager.getInstance().getCounter("MonitorWithoutAnyTag");*
In this case output metric id will be **MonitorWithoutAnyTag)** , correct output metric id is **MonitorWithoutAnyTag** ,not include a **')'**

Also fix MetricsLoader load this style of metric id.
