### PR TITLE
[SCB-372] support user set metrics prometheus exporter address not only port

### DIFF
--- a/metrics/metrics-integration/metrics-prometheus/src/main/java/org/apache/servicecomb/metrics/prometheus/MetricsHttpPublisher.java
+++ b/metrics/metrics-integration/metrics-prometheus/src/main/java/org/apache/servicecomb/metrics/prometheus/MetricsHttpPublisher.java
@@ -17,7 +17,6 @@
 
 package org.apache.servicecomb.metrics.prometheus;
 
-import java.io.IOException;
 import java.net.InetSocketAddress;
 
 import org.apache.servicecomb.foundation.common.exceptions.ServiceCombException;
@@ -37,20 +36,34 @@ import io.prometheus.client.exporter.HTTPServer;
 public class MetricsHttpPublisher implements ApplicationListener<ApplicationEvent> {
   private static final Logger LOGGER = LoggerFactory.getLogger(MetricsHttpPublisher.class);
 
-  private static final String METRICS_PROMETHEUS_PORT = "servicecomb.metrics.prometheus.port";
+  private static final String METRICS_PROMETHEUS_ADDRESS = "servicecomb.metrics.prometheus.address";
 
   private HTTPServer httpServer;
 
   public MetricsHttpPublisher() {
     //prometheus default port allocation is here : https://github.com/prometheus/prometheus/wiki/Default-port-allocations
-    int publishPort = DynamicPropertyFactory.getInstance().getIntProperty(METRICS_PROMETHEUS_PORT, 9696).get();
-    MetricsCollector metricsCollector = new MetricsCollector();
-    metricsCollector.register();
-    try {
-      this.httpServer = new HTTPServer(new InetSocketAddress(publishPort), CollectorRegistry.defaultRegistry, true);
-      LOGGER.info("Prometheus httpServer listened {}.", publishPort);
-    } catch (IOException e) {
-      throw new ServiceCombException("create http publish server failed", e);
+    this.init(
+        DynamicPropertyFactory.getInstance().getStringProperty(METRICS_PROMETHEUS_ADDRESS, "localhost:9696").get());
+  }
+
+  public MetricsHttpPublisher(String address) {
+    this.init(address);
+  }
+
+  private void init(String address) {
+    String[] hostAndPort = address.split(":");
+    if (hostAndPort.length == 2) {
+      try {
+        InetSocketAddress socketAddress = new InetSocketAddress(hostAndPort[0], Integer.parseInt(hostAndPort[1]));
+        MetricsCollector metricsCollector = new MetricsCollector();
+        metricsCollector.register();
+        this.httpServer = new HTTPServer(socketAddress, CollectorRegistry.defaultRegistry, true);
+        LOGGER.info("Prometheus httpServer listened : {}.", address);
+      } catch (Exception e) {
+        throw new ServiceCombException("create http publish server failed,may bad address : " + address, e);
+      }
+    } else {
+      throw new ServiceCombException("create http publish server failed,bad address : " + address);
     }
   }
 

--- a/metrics/metrics-integration/metrics-prometheus/src/test/java/org/apache/servicecomb/metrics/prometheus/TestMetricsHttpPublisher.java
+++ b/metrics/metrics-integration/metrics-prometheus/src/test/java/org/apache/servicecomb/metrics/prometheus/TestMetricsHttpPublisher.java
@@ -32,21 +32,21 @@ public class TestMetricsHttpPublisher {
   public void testBadPublishAddress() {
     thrown.expect(ServiceCombException.class);
     new MetricsHttpPublisher("a:b:c");
-    Assert.fail("testPublishAddress failed : a:b:c");
+    Assert.fail("testBadPublishAddress failed,this address must throw ServiceCombException : a:b:c");
   }
 
   @Test
   public void testBadPublishAddress_BadPort() {
     thrown.expect(ServiceCombException.class);
     new MetricsHttpPublisher("localhost:xxxx");
-    Assert.fail("testPublishAddress failed : localhost:xxxx");
+    Assert.fail("testBadPublishAddress failed,this address must throw ServiceCombException : localhost:xxxx");
   }
 
   @Test
   public void testBadPublishAddress_ToLargePort() {
     thrown.expect(ServiceCombException.class);
     new MetricsHttpPublisher("localhost:9999999");
-    Assert.fail("testPublishAddress failed : localhost:9999999");
+    Assert.fail("testBadPublishAddress failed,this address must throw ServiceCombException : localhost:9999999");
   }
 
   @Test

--- a/metrics/metrics-integration/metrics-prometheus/src/test/java/org/apache/servicecomb/metrics/prometheus/TestMetricsHttpPublisher.java
+++ b/metrics/metrics-integration/metrics-prometheus/src/test/java/org/apache/servicecomb/metrics/prometheus/TestMetricsHttpPublisher.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.servicecomb.metrics.prometheus;
+
+import org.apache.servicecomb.foundation.common.exceptions.ServiceCombException;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class TestMetricsHttpPublisher {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void testBadPublishAddress() {
+    thrown.expect(ServiceCombException.class);
+    new MetricsHttpPublisher("a:b:c");
+    Assert.fail("testPublishAddress failed : a:b:c");
+  }
+
+  @Test
+  public void testBadPublishAddress_BadPort() {
+    thrown.expect(ServiceCombException.class);
+    new MetricsHttpPublisher("localhost:xxxx");
+    Assert.fail("testPublishAddress failed : localhost:xxxx");
+  }
+
+  @Test
+  public void testBadPublishAddress_ToLargePort() {
+    thrown.expect(ServiceCombException.class);
+    new MetricsHttpPublisher("localhost:9999999");
+    Assert.fail("testPublishAddress failed : localhost:9999999");
+  }
+
+  @Test
+  public void testRightPublishAddress() {
+    new MetricsHttpPublisher("localhost:43234");
+  }
+}


### PR DESCRIPTION
Signed-off-by: zhengyangyong <yangyong.zheng@huawei.com>

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/SCB) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[SCB-XXX] Fixes bug in ApproximateQuantiles`, where you replace `SCB-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean install` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---
Before:
```yaml
servicecomb:
  metrics:
    prometheus:
      port: 9696
```
Now:
```yaml
servicecomb:
  metrics:
    prometheus:
      address: localhost:9696
```