### PR TITLE
SCB-405 support to disable the discovery client with configuration

### DIFF
--- a/spring-boot-starter/spring-boot-starter-discovery/src/main/java/org/apache/servicecomb/springboot/starter/discovery/CseDiscoveryClientConfiguration.java
+++ b/spring-boot-starter/spring-boot-starter-discovery/src/main/java/org/apache/servicecomb/springboot/starter/discovery/CseDiscoveryClientConfiguration.java
@@ -17,6 +17,7 @@
 package org.apache.servicecomb.springboot.starter.discovery;
 
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.cloud.client.discovery.noop.NoopDiscoveryClientAutoConfiguration;
 import org.springframework.context.annotation.Bean;
@@ -28,6 +29,7 @@ import org.springframework.core.annotation.Order;
 public class CseDiscoveryClientConfiguration {
   @Bean
   @Order(5000)
+  @ConditionalOnProperty(value = "servicecomb.discoveryClient.enabled", havingValue = "true", matchIfMissing = true)
   public DiscoveryClient cseDiscoveryClient() {
     return new CseDiscoveryClient();
   }


### PR DESCRIPTION
Now user can disable the discovery client with below configuration:

```
servicecomb:
   discoveryClient:
      enabled: false
```
