### PR TITLE
[SCB-447] Optimize SPIServiceUtils

### DIFF
--- a/common/common-rest/src/test/java/org/apache/servicecomb/common/rest/TestAbstractRestInvocation.java
+++ b/common/common-rest/src/test/java/org/apache/servicecomb/common/rest/TestAbstractRestInvocation.java
@@ -656,7 +656,7 @@ public class TestAbstractRestInvocation {
     }.getMockInstance();
 
     initRestInvocation();
-    List<HttpServerFilter> httpServerFilters = SPIServiceUtils.getSortedService(HttpServerFilter.class);
+    List<HttpServerFilter> httpServerFilters = SPIServiceUtils.loadSortedService(HttpServerFilter.class);
     httpServerFilters.add(filter);
     restInvocation.setHttpServerFilters(httpServerFilters);
 

--- a/foundations/foundation-common/src/test/java/org/apache/servicecomb/foundation/common/utils/SPIServiceDef0Impl.java
+++ b/foundations/foundation-common/src/test/java/org/apache/servicecomb/foundation/common/utils/SPIServiceDef0Impl.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.servicecomb.foundation.common.utils;
+
+public class SPIServiceDef0Impl implements SPIServiceDef0 {
+
+}

--- a/foundations/foundation-common/src/test/java/org/apache/servicecomb/foundation/common/utils/TestSPIServiceUtils.java
+++ b/foundations/foundation-common/src/test/java/org/apache/servicecomb/foundation/common/utils/TestSPIServiceUtils.java
@@ -18,6 +18,7 @@
 package org.apache.servicecomb.foundation.common.utils;
 
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.ServiceLoader;
 
@@ -46,6 +47,19 @@ public class TestSPIServiceUtils {
   public void testGetTargetServiceNotNull() {
     SPIServiceDef service = SPIServiceUtils.getTargetService(SPIServiceDef.class);
     Assert.assertTrue(SPIServiceDef.class.isInstance(service));
+
+    Assert.assertSame(service, SPIServiceUtils.getTargetService(SPIServiceDef.class));
+  }
+
+  @Test
+  public void testGetTargetService_special_null() {
+    Assert.assertNull(SPIServiceUtils.getTargetService(SPIServiceDef0.class, SPIServiceDef0Impl.class));
+  }
+
+  @Test
+  public void testGetTargetService_special_notNull() {
+    SPIServiceDef service = SPIServiceUtils.getTargetService(SPIServiceDef.class, SPIServiceDefImpl.class);
+    Assert.assertTrue(SPIServiceDefImpl.class.isInstance(service));
   }
 
   @Test
@@ -68,6 +82,15 @@ public class TestSPIServiceUtils {
     };
 
     Assert.assertThat(SPIServiceUtils.getSortedService(Ordered.class), Matchers.contains(o1, o2));
+    Assert.assertThat(SPIServiceUtils.getAllService(Ordered.class), Matchers.contains(o1, o2));
     Assert.assertThat(SPIServiceUtils.getPriorityHighestService(Ordered.class), Matchers.is(o1));
+
+    Map<Class<?>, List<Object>> cache = Deencapsulation.getField(SPIServiceUtils.class, "cache");
+    cache.clear();
+  }
+
+  @Test
+  public void getPriorityHighestService_null() {
+    Assert.assertNull(SPIServiceUtils.getPriorityHighestService(SPIServiceDef0.class));
   }
 }

--- a/foundations/foundation-metrics/src/main/java/org/apache/servicecomb/foundation/metrics/MetricsBootstrap.java
+++ b/foundations/foundation-metrics/src/main/java/org/apache/servicecomb/foundation/metrics/MetricsBootstrap.java
@@ -22,8 +22,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.servicecomb.foundation.common.utils.SPIServiceUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.Lists;
 import com.google.common.eventbus.EventBus;
@@ -32,8 +30,6 @@ import com.netflix.spectator.api.CompositeRegistry;
 import com.netflix.spectator.api.Meter;
 
 public class MetricsBootstrap {
-  private static final Logger LOGGER = LoggerFactory.getLogger(MetricsBootstrap.class);
-
   private CompositeRegistry globalRegistry;
 
   private EventBus eventBus;
@@ -60,8 +56,6 @@ public class MetricsBootstrap {
 
   protected void loadMetricsInitializers() {
     SPIServiceUtils.getSortedService(MetricsInitializer.class).forEach(initializer -> {
-      LOGGER.info("Found MetricsInitializer: {}", initializer.getClass().getName());
-
       initializer.init(globalRegistry, eventBus, config);
     });
   }

--- a/service-registry/src/test/java/org/apache/servicecomb/serviceregistry/consumer/TestMicroserviceManager.java
+++ b/service-registry/src/test/java/org/apache/servicecomb/serviceregistry/consumer/TestMicroserviceManager.java
@@ -90,32 +90,6 @@ public class TestMicroserviceManager {
   }
 
   @Test
-  public void testCreateRuleServiceTooMany() throws Exception {
-    new Expectations(RegistryUtils.class) {
-      {
-        RegistryUtils.findServiceInstances(appId, anyString, DefinitionConst.VERSION_RULE_ALL, null);
-        result = microserviceInstances;
-      }
-    };
-
-    for (int i = 0; i < 1005; i++) {
-      MicroserviceVersionRule microserviceVersionRule =
-          microserviceManager.getOrCreateMicroserviceVersionRule(serviceName + i, versionRule);
-      Assert.assertEquals("0.0.0+", microserviceVersionRule.getVersionRule().getVersionRule());
-      Assert.assertNull(microserviceVersionRule.getLatestMicroserviceVersion());
-      if (i == 499) {
-        Thread.sleep(1);
-      }
-    }
-
-    Assert.assertEquals(1005, cachedVersions.size());
-    Assert.assertEquals("msName1004", cachedVersions.get("msName1004").getMicroserviceName());
-    Assert.assertEquals("msName1000", cachedVersions.get("msName1000").getMicroserviceName());
-    Assert.assertEquals("msName500", cachedVersions.get("msName500").getMicroserviceName());
-    Assert.assertEquals("msName0", cachedVersions.get("msName0").getMicroserviceName());
-  }
-
-  @Test
   public void testCreateRuleServiceNotExists() {
     new Expectations(RegistryUtils.class) {
       {

--- a/swagger/swagger-generator/generator-core/src/main/java/org/apache/servicecomb/swagger/generator/core/CompositeSwaggerGeneratorContext.java
+++ b/swagger/swagger-generator/generator-core/src/main/java/org/apache/servicecomb/swagger/generator/core/CompositeSwaggerGeneratorContext.java
@@ -20,24 +20,16 @@ package org.apache.servicecomb.swagger.generator.core;
 import java.util.List;
 
 import org.apache.servicecomb.foundation.common.utils.SPIServiceUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.context.EmbeddedValueResolverAware;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringValueResolver;
 
 @Component
 public class CompositeSwaggerGeneratorContext implements EmbeddedValueResolverAware {
-  private static final Logger LOGGER = LoggerFactory.getLogger(CompositeSwaggerGeneratorContext.class);
-
   private List<SwaggerGeneratorContext> contextList;
 
   public CompositeSwaggerGeneratorContext() {
     contextList = SPIServiceUtils.getSortedService(SwaggerGeneratorContext.class);
-
-    for (SwaggerGeneratorContext context : contextList) {
-      LOGGER.info("Found swagger generator context: {}", context.getClass().getName());
-    }
   }
 
   @Override

--- a/swagger/swagger-invocation/invocation-core/src/main/java/org/apache/servicecomb/swagger/invocation/response/ResponseMapperFactorys.java
+++ b/swagger/swagger-invocation/invocation-core/src/main/java/org/apache/servicecomb/swagger/invocation/response/ResponseMapperFactorys.java
@@ -21,12 +21,8 @@ import java.util.List;
 
 import org.apache.servicecomb.foundation.common.utils.SPIServiceUtils;
 import org.apache.servicecomb.swagger.invocation.converter.ConverterMgr;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class ResponseMapperFactorys<MAPPER> {
-  private static final Logger LOGGER = LoggerFactory.getLogger(ResponseMapperFactorys.class);
-
   private List<ResponseMapperFactory<MAPPER>> factorys;
 
   public ResponseMapperFactorys(Class<? extends ResponseMapperFactory<MAPPER>> factoryCls, ConverterMgr converterMgr) {
@@ -37,9 +33,6 @@ public class ResponseMapperFactorys<MAPPER> {
   @SuppressWarnings("unchecked")
   public ResponseMapperFactorys(Class<? extends ResponseMapperFactory<MAPPER>> factoryCls) {
     factorys = (List<ResponseMapperFactory<MAPPER>>) SPIServiceUtils.getSortedService(factoryCls);
-    factorys.forEach(factory -> {
-      LOGGER.info("found factory {} of {}:", factory.getClass().getName(), factoryCls.getName());
-    });
   }
 
   public void setConverterMgr(ConverterMgr converterMgr) {

--- a/transports/transport-rest/transport-rest-client/src/main/java/org/apache/servicecomb/transport/rest/client/http/VertxHttpMethod.java
+++ b/transports/transport-rest/transport-rest-client/src/main/java/org/apache/servicecomb/transport/rest/client/http/VertxHttpMethod.java
@@ -56,12 +56,6 @@ public class VertxHttpMethod {
 
   static List<HttpClientFilter> httpClientFilters = SPIServiceUtils.getSortedService(HttpClientFilter.class);
 
-  static {
-    for (HttpClientFilter filter : httpClientFilters) {
-      LOGGER.info("Found HttpClientFilter: {}.", filter.getClass().getName());
-    }
-  }
-
   public void doMethod(HttpClientWithContext httpClientWithContext, Invocation invocation,
       AsyncResponse asyncResp) throws Exception {
     OperationMeta operationMeta = invocation.getOperationMeta();

--- a/transports/transport-rest/transport-rest-servlet/src/test/java/org/apache/servicecomb/transport/rest/servlet/TestRestServletProducerInvocation.java
+++ b/transports/transport-rest/transport-rest-servlet/src/test/java/org/apache/servicecomb/transport/rest/servlet/TestRestServletProducerInvocation.java
@@ -26,7 +26,6 @@ import org.apache.servicecomb.common.rest.RestProducerInvocation;
 import org.apache.servicecomb.common.rest.definition.RestOperationMeta;
 import org.apache.servicecomb.common.rest.filter.HttpServerFilter;
 import org.apache.servicecomb.core.definition.OperationMeta;
-import org.apache.servicecomb.foundation.common.utils.SPIServiceUtils;
 import org.apache.servicecomb.foundation.vertx.http.HttpServletRequestEx;
 import org.apache.servicecomb.foundation.vertx.http.StandardHttpServletRequestEx;
 import org.junit.Assert;
@@ -60,7 +59,7 @@ public class TestRestServletProducerInvocation {
     };
 
     List<HttpServerFilter> httpServerFilters = Arrays.asList(f1);
-    new Expectations(SPIServiceUtils.class) {
+    new Expectations() {
       {
         f1.needCacheRequest(operationMeta);
         result = true;
@@ -76,7 +75,7 @@ public class TestRestServletProducerInvocation {
   @Test
   public void collectCacheRequestCacheTrue(@Mocked HttpServerFilter f1) {
     List<HttpServerFilter> httpServerFilters = Arrays.asList(f1);
-    new Expectations(SPIServiceUtils.class) {
+    new Expectations() {
       {
         f1.needCacheRequest(operationMeta);
         result = true;
@@ -90,7 +89,7 @@ public class TestRestServletProducerInvocation {
   @Test
   public void collectCacheRequestCacheFalse(@Mocked HttpServerFilter f1) {
     List<HttpServerFilter> httpServerFilters = Arrays.asList(f1);
-    new Expectations(SPIServiceUtils.class) {
+    new Expectations() {
       {
         f1.needCacheRequest(operationMeta);
         result = false;

--- a/transports/transport-rest/transport-rest-vertx/src/main/java/org/apache/servicecomb/transport/rest/vertx/AbstractVertxHttpDispatcher.java
+++ b/transports/transport-rest/transport-rest-vertx/src/main/java/org/apache/servicecomb/transport/rest/vertx/AbstractVertxHttpDispatcher.java
@@ -35,12 +35,6 @@ public abstract class AbstractVertxHttpDispatcher implements VertxHttpDispatcher
 
   protected List<HttpServerFilter> httpServerFilters = SPIServiceUtils.getSortedService(HttpServerFilter.class);
 
-  public AbstractVertxHttpDispatcher() {
-    for (HttpServerFilter filter : httpServerFilters) {
-      LOGGER.info("Found HttpServerFilter: {}.", filter.getClass().getName());
-    }
-  }
-
   protected BodyHandler createBodyHandler() {
     RestBodyHandler bodyHandler = new RestBodyHandler();
 

--- a/transports/transport-rest/transport-rest-vertx/src/main/java/org/apache/servicecomb/transport/rest/vertx/RestServerVerticle.java
+++ b/transports/transport-rest/transport-rest-vertx/src/main/java/org/apache/servicecomb/transport/rest/vertx/RestServerVerticle.java
@@ -94,7 +94,6 @@ public class RestServerVerticle extends AbstractVerticle {
   private void initDispatcher(Router mainRouter) {
     List<VertxHttpDispatcher> dispatchers = SPIServiceUtils.getSortedService(VertxHttpDispatcher.class);
     for (VertxHttpDispatcher dispatcher : dispatchers) {
-      LOGGER.info("init vertx http dispatcher {}", dispatcher.getClass().getName());
       dispatcher.init(mainRouter);
     }
   }


### PR DESCRIPTION
1.cache SPI service instances, avoid create new instance every time
2.support find special IPML instance

![image](https://user-images.githubusercontent.com/16874843/38077152-9441d3ce-336a-11e8-912b-d6ca2fd30510.png)
