### PR TITLE
[SCB-516] fix accessLog traceId printing problem in EdgeService

### DIFF
--- a/core/src/main/java/org/apache/servicecomb/core/tracing/BraveTraceIdGenerator.java
+++ b/core/src/main/java/org/apache/servicecomb/core/tracing/BraveTraceIdGenerator.java
@@ -24,7 +24,7 @@ public class BraveTraceIdGenerator implements TraceIdGenerator {
 
   @Override
   public String generateStringId() {
-    return String.valueOf(Platform.get().nextTraceIdHigh());
+    return Long.toHexString(Platform.get().nextTraceIdHigh());
   }
 
   private BraveTraceIdGenerator() {

--- a/core/src/test/java/org/apache/servicecomb/core/tracing/BraveTraceIdGeneratorTest.java
+++ b/core/src/test/java/org/apache/servicecomb/core/tracing/BraveTraceIdGeneratorTest.java
@@ -31,7 +31,7 @@ public class BraveTraceIdGeneratorTest {
 
     String traceId = traceIdGenerator.generateStringId();
     try {
-      Long.valueOf(traceId);
+      Long.parseLong(traceId, 16);
     } catch (NumberFormatException e) {
       fail("wrong traceId format: " + traceId);
     }

--- a/handlers/handler-tracing-zipkin/src/test/java/org/apache/servicecomb/tracing/zipkin/ZipkinProviderDelegateTest.java
+++ b/handlers/handler-tracing-zipkin/src/test/java/org/apache/servicecomb/tracing/zipkin/ZipkinProviderDelegateTest.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.servicecomb.tracing.zipkin;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.servicecomb.core.Invocation;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import brave.propagation.Propagation.Getter;
+import mockit.Deencapsulation;
+
+public class ZipkinProviderDelegateTest {
+  @Test
+  public void testGetterOnGetSpanId() {
+    Getter<Invocation, String> getter = Deencapsulation
+        .getField(ZipkinProviderDelegate.class, "INVOCATION_STRING_GETTER");
+
+    Invocation invocation = Mockito.mock(Invocation.class);
+    Map<String, String> context = new HashMap<>();
+
+    Mockito.when(invocation.getContext()).thenReturn(context);
+
+    // if there is no spanId or traceId, then result is null
+    String spanId = getter.get(invocation, ZipkinProviderDelegate.SPAN_ID_HEADER_NAME);
+    Assert.assertNull(spanId);
+
+    // if there is no spanId but traceId, then traceId will be returned as result
+    final String testTraceId = "testTraceId";
+    context.put(ZipkinProviderDelegate.TRACE_ID_HEADER_NAME, testTraceId);
+    spanId = getter.get(invocation, ZipkinProviderDelegate.SPAN_ID_HEADER_NAME);
+    Assert.assertEquals(testTraceId, spanId);
+
+    // if there is spanId, then spanId will be returned
+    final String testSpanId = "testSpanId";
+    context.put(ZipkinProviderDelegate.SPAN_ID_HEADER_NAME, testSpanId);
+    spanId = getter.get(invocation, ZipkinProviderDelegate.SPAN_ID_HEADER_NAME);
+    Assert.assertEquals(testSpanId, spanId);
+  }
+
+  @Test
+  public void testGetterOnGetOtherContent() {
+    Getter<Invocation, String> getter = Deencapsulation
+        .getField(ZipkinProviderDelegate.class, "INVOCATION_STRING_GETTER");
+
+    Invocation invocation = Mockito.mock(Invocation.class);
+    Map<String, String> context = new HashMap<>();
+
+    Mockito.when(invocation.getContext()).thenReturn(context);
+
+    final String key = "key";
+    String value = getter.get(invocation, key);
+    Assert.assertNull(value);
+
+    final String expectedValue = "value";
+    context.put(key, expectedValue);
+    value = getter.get(invocation, key);
+    Assert.assertEquals(expectedValue, value);
+  }
+}

--- a/transports/transport-rest/transport-rest-vertx/src/main/java/org/apache/servicecomb/transport/rest/vertx/RestServerVerticle.java
+++ b/transports/transport-rest/transport-rest-vertx/src/main/java/org/apache/servicecomb/transport/rest/vertx/RestServerVerticle.java
@@ -30,6 +30,7 @@ import org.apache.servicecomb.foundation.vertx.VertxTLSBuilder;
 import org.apache.servicecomb.transport.rest.vertx.accesslog.AccessLogConfiguration;
 import org.apache.servicecomb.transport.rest.vertx.accesslog.impl.AccessLogHandler;
 import org.apache.servicecomb.transport.rest.vertx.accesslog.parser.impl.DefaultAccessLogPatternParser;
+import org.apache.servicecomb.transport.rest.vertx.trace.TracePrepareHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -68,16 +69,21 @@ public class RestServerVerticle extends AbstractVerticle {
         return;
       }
       Router mainRouter = Router.router(vertx);
+      mountTracePrepareHandler(mainRouter);
       mountAccessLogHandler(mainRouter);
       initDispatcher(mainRouter);
       HttpServer httpServer = createHttpServer();
       httpServer.requestHandler(mainRouter::accept);
       startListen(httpServer, startFuture);
-    } catch(Throwable e) {
+    } catch (Throwable e) {
       // vert.x got some states that not print error and execute call back in VertexUtils.blockDeploy, we add a log our self.
       LOGGER.error("", e);
       throw e;
     }
+  }
+
+  private void mountTracePrepareHandler(Router mainRouter) {
+    mainRouter.route().handler(new TracePrepareHandler());
   }
 
   private void mountAccessLogHandler(Router mainRouter) {

--- a/transports/transport-rest/transport-rest-vertx/src/main/java/org/apache/servicecomb/transport/rest/vertx/accesslog/impl/AccessLogHandler.java
+++ b/transports/transport-rest/transport-rest-vertx/src/main/java/org/apache/servicecomb/transport/rest/vertx/accesslog/impl/AccessLogHandler.java
@@ -40,7 +40,7 @@ public class AccessLogHandler implements Handler<RoutingContext> {
     AccessLogParam<RoutingContext> accessLogParam = new AccessLogParam<>();
     accessLogParam.setStartMillisecond(System.currentTimeMillis()).setContextData(context);
 
-    context.addBodyEndHandler(v -> LOGGER.info(accessLogGenerator.generateLog(accessLogParam)));
+    context.response().endHandler(event -> LOGGER.info(accessLogGenerator.generateLog(accessLogParam)));
 
     context.next();
   }

--- a/transports/transport-rest/transport-rest-vertx/src/main/java/org/apache/servicecomb/transport/rest/vertx/trace/TracePrepareHandler.java
+++ b/transports/transport-rest/transport-rest-vertx/src/main/java/org/apache/servicecomb/transport/rest/vertx/trace/TracePrepareHandler.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.servicecomb.transport.rest.vertx.trace;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.servicecomb.core.Const;
+import org.apache.servicecomb.core.tracing.BraveTraceIdGenerator;
+
+import io.vertx.core.Handler;
+import io.vertx.ext.web.RoutingContext;
+
+public class TracePrepareHandler implements Handler<RoutingContext> {
+  @Override
+  public void handle(RoutingContext context) {
+    String traceId = context.request().getHeader(Const.TRACE_ID_NAME);
+    if (StringUtils.isEmpty(traceId)) {
+      traceId = BraveTraceIdGenerator.INSTANCE.generateStringId();
+      context.request().headers().add(Const.TRACE_ID_NAME, traceId);
+    }
+
+    context.next();
+  }
+}

--- a/transports/transport-rest/transport-rest-vertx/src/test/java/org/apache/servicecomb/transport/rest/vertx/accesslog/element/impl/TraceIdItemTest.java
+++ b/transports/transport-rest/transport-rest-vertx/src/test/java/org/apache/servicecomb/transport/rest/vertx/accesslog/element/impl/TraceIdItemTest.java
@@ -30,6 +30,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import io.vertx.core.http.HttpServerRequest;
 import io.vertx.ext.web.RoutingContext;
 import mockit.Deencapsulation;
 
@@ -37,7 +38,7 @@ public class TraceIdItemTest {
   private static final TraceIdItem ELEMENT = new TraceIdItem();
 
   @Test
-  public void testGetFormattedElement() {
+  public void testGetFormattedElementFromInvocationContext() {
     AccessLogParam<RoutingContext> param = new AccessLogParam<>();
     RoutingContext routingContext = Mockito.mock(RoutingContext.class);
     Map<String, Object> data = new HashMap<>();
@@ -49,6 +50,30 @@ public class TraceIdItemTest {
     Deencapsulation.setField(restProducerInvocation, "invocation", invocation);
     Mockito.when(routingContext.data()).thenReturn(data);
     data.put("servicecomb-rest-producer-invocation", restProducerInvocation);
+
+    param.setContextData(routingContext);
+
+    String result = ELEMENT.getFormattedItem(param);
+    Assert.assertThat(result, is(traceIdTest));
+  }
+
+  @Test
+  public void testGetFormattedElementFromRequestHeader() {
+    AccessLogParam<RoutingContext> param = new AccessLogParam<>();
+    RoutingContext routingContext = Mockito.mock(RoutingContext.class);
+    Map<String, Object> data = new HashMap<>();
+    RestProducerInvocation restProducerInvocation = new RestProducerInvocation();
+    Invocation invocation = Mockito.mock(Invocation.class);
+    String traceIdTest = "traceIdTest";
+
+    Mockito.when(invocation.getContext(Const.TRACE_ID_NAME)).thenReturn(null);
+    Deencapsulation.setField(restProducerInvocation, "invocation", invocation);
+    Mockito.when(routingContext.data()).thenReturn(data);
+    data.put("servicecomb-rest-producer-invocation", restProducerInvocation);
+
+    HttpServerRequest request = Mockito.mock(HttpServerRequest.class);
+    Mockito.when(request.getHeader(Const.TRACE_ID_NAME)).thenReturn(traceIdTest);
+    Mockito.when(routingContext.request()).thenReturn(request);
 
     param.setContextData(routingContext);
 
@@ -69,6 +94,10 @@ public class TraceIdItemTest {
     Mockito.when(routingContext.data()).thenReturn(data);
     data.put("servicecomb-rest-producer-invocation", restProducerInvocation);
 
+    HttpServerRequest request = Mockito.mock(HttpServerRequest.class);
+    Mockito.when(request.getHeader(Const.TRACE_ID_NAME)).thenReturn(null);
+    Mockito.when(routingContext.request()).thenReturn(request);
+
     param.setContextData(routingContext);
 
     String result = ELEMENT.getFormattedItem(param);
@@ -86,6 +115,11 @@ public class TraceIdItemTest {
     Map<String, Object> data = new HashMap<>();
 
     Mockito.when(routingContext.data()).thenReturn(data);
+
+    HttpServerRequest request = Mockito.mock(HttpServerRequest.class);
+    Mockito.when(request.getHeader(Const.TRACE_ID_NAME)).thenReturn(null);
+    Mockito.when(routingContext.request()).thenReturn(request);
+
     param.setContextData(routingContext);
 
     String result = ELEMENT.getFormattedItem(param);
@@ -96,6 +130,10 @@ public class TraceIdItemTest {
   public void testGetFormattedElementOnDataIsNull() {
     AccessLogParam<RoutingContext> param = new AccessLogParam<>();
     RoutingContext routingContext = Mockito.mock(RoutingContext.class);
+
+    HttpServerRequest request = Mockito.mock(HttpServerRequest.class);
+    Mockito.when(request.getHeader(Const.TRACE_ID_NAME)).thenReturn(null);
+    Mockito.when(routingContext.request()).thenReturn(request);
 
     param.setContextData(routingContext);
     Mockito.when(routingContext.data()).thenReturn(null);

--- a/transports/transport-rest/transport-rest-vertx/src/test/java/org/apache/servicecomb/transport/rest/vertx/trace/TracePrepareHandlerTest.java
+++ b/transports/transport-rest/transport-rest-vertx/src/test/java/org/apache/servicecomb/transport/rest/vertx/trace/TracePrepareHandlerTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.servicecomb.transport.rest.vertx.trace;
+
+import org.apache.servicecomb.core.Const;
+import org.apache.servicecomb.core.tracing.BraveTraceIdGenerator;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import io.vertx.core.MultiMap;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.impl.headers.VertxHttpHeaders;
+import io.vertx.ext.web.RoutingContext;
+import mockit.Expectations;
+
+public class TracePrepareHandlerTest {
+  private static final TracePrepareHandler HANDLER = new TracePrepareHandler();
+
+  @Test
+  public void handleWhenTraceIdExists() {
+    RoutingContext context = Mockito.mock(RoutingContext.class);
+    HttpServerRequest request = Mockito.mock(HttpServerRequest.class);
+    String traceId = "testTraceId";
+
+    Mockito.when(context.request()).thenReturn(request);
+    Mockito.when(request.getHeader(Const.TRACE_ID_NAME)).thenReturn(traceId);
+
+    HANDLER.handle(context);
+
+    Mockito.verify(request, Mockito.times(0)).headers();
+  }
+
+  @Test
+  public void handleWhenSetNewTraceId() {
+    RoutingContext context = Mockito.mock(RoutingContext.class);
+    HttpServerRequest request = Mockito.mock(HttpServerRequest.class);
+    String traceId = "testTraceId";
+    MultiMap multimapHeader = new VertxHttpHeaders();
+
+    new Expectations(BraveTraceIdGenerator.class) {
+      {
+        BraveTraceIdGenerator.INSTANCE.generateStringId();
+        result = traceId;
+      }
+    };
+
+    Mockito.when(context.request()).thenReturn(request);
+    Mockito.when(request.getHeader(Const.TRACE_ID_NAME)).thenReturn(null);
+    Mockito.when(request.headers()).thenReturn(multimapHeader);
+
+    HANDLER.handle(context);
+
+    Mockito.verify(request, Mockito.times(1)).headers();
+    Assert.assertEquals(1, multimapHeader.size());
+    Assert.assertEquals(traceId, multimapHeader.get(Const.TRACE_ID_NAME));
+  }
+}


### PR DESCRIPTION
Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/SCB) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[SCB-XXX] Fixes bug in ApproximateQuantiles`, where you replace `SCB-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean install` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---
See details in [SCB-516](https://issues.apache.org/jira/browse/SCB-516).
- add a TracePrepareHandler to set traceId
- make TraceIdItem can get traceId from request headers

![](https://issues.apache.org/jira/secure/attachment/12920232/ComplieWarning.PNG "compile warning")