### PR TITLE
[SCB-521] Config of Spring Boot should takes higher priority than microservice.yaml

### DIFF
--- a/foundations/foundation-config/src/main/java/org/apache/servicecomb/config/ConfigUtil.java
+++ b/foundations/foundation-config/src/main/java/org/apache/servicecomb/config/ConfigUtil.java
@@ -130,17 +130,17 @@ public final class ConfigUtil {
     duplicateServiceCombConfigToCse(config,
         convertEnvVariable(new ConcurrentMapConfiguration(new EnvironmentConfiguration())),
         "configFromEnvironment");
-    duplicateServiceCombConfigToCse(config,
-        new DynamicConfiguration(
-            new MicroserviceConfigurationSource(configModelList), new NeverStartPollingScheduler()),
-        "configFromYamlFile");
-    // If there is extra configurations, add it into config. Extra config has lowest priority.
+    // If there is extra configurations, add it into config.
     EXTRA_CONFIG_MAP.entrySet().stream()
         .filter(mapEntry -> !mapEntry.getValue().isEmpty())
         .forEachOrdered(configMapEntry ->
             duplicateServiceCombConfigToCse(config,
                 new ConcurrentMapConfiguration(configMapEntry.getValue()),
                 configMapEntry.getKey()));
+    duplicateServiceCombConfigToCse(config,
+        new DynamicConfiguration(
+            new MicroserviceConfigurationSource(configModelList), new NeverStartPollingScheduler()),
+        "configFromYamlFile");
 
     return config;
   }

--- a/foundations/foundation-config/src/test/java/org/apache/servicecomb/config/TestConfigUtil.java
+++ b/foundations/foundation-config/src/test/java/org/apache/servicecomb/config/TestConfigUtil.java
@@ -326,14 +326,15 @@ public class TestConfigUtil {
     String extraConfigValue = "value";
     String overriddenConfigKey = "servicecomb.cse.servicecomb.file";
     extraConfig.put(extraConfigKey, extraConfigValue);
-    extraConfig.put(overriddenConfigKey, "should_be_overridden");
+    final String propertyHigherPriority = "higher_priority";
+    extraConfig.put(overriddenConfigKey, propertyHigherPriority);
 
     ConfigUtil.addExtraConfig("testExtraConfig", extraConfig);
 
     ConcurrentCompositeConfiguration localConfiguration = ConfigUtil.createLocalConfig();
 
     Assert.assertEquals(extraConfigValue, localConfiguration.getProperty(extraConfigKey));
-    Assert.assertEquals("value", localConfiguration.getString(overriddenConfigKey));
+    Assert.assertEquals(propertyHigherPriority, localConfiguration.getString(overriddenConfigKey));
   }
 
   @SuppressWarnings("unchecked")

--- a/foundations/foundation-config/src/test/resources/microservice.yaml
+++ b/foundations/foundation-config/src/test/resources/microservice.yaml
@@ -64,4 +64,4 @@ service_description:
 servicecomb:
   cse:
     servicecomb:
-      file: value
+      file: value # this is a config for TestConfigUtil.testCreateLocalConfigWithExtraConfig()

--- a/integration-tests/spring-jaxrs-tests/src/test/resources/application.properties
+++ b/integration-tests/spring-jaxrs-tests/src/test/resources/application.properties
@@ -16,5 +16,4 @@
 #
 
 property.test0=from_properties
-property.test4=from_properties
 property.test5=from_properties

--- a/integration-tests/spring-jaxrs-tests/src/test/resources/microservice.yaml
+++ b/integration-tests/spring-jaxrs-tests/src/test/resources/microservice.yaml
@@ -16,5 +16,6 @@
 # ---------------------------------------------------------------------------
 
 property:
+  test2: from_microservice_yaml
   test4: from_microservice_yaml
   test5: from_microservice_yaml

--- a/integration-tests/spring-zuul-tracing-tests/src/test/resources/application.properties
+++ b/integration-tests/spring-zuul-tracing-tests/src/test/resources/application.properties
@@ -18,5 +18,4 @@
 spring.main.web-environment=true
 
 property.test0=from_properties
-property.test4=from_properties
 property.test5=from_properties

--- a/integration-tests/spring-zuul-tracing-tests/src/test/resources/microservice.yaml
+++ b/integration-tests/spring-zuul-tracing-tests/src/test/resources/microservice.yaml
@@ -38,5 +38,6 @@ servicecomb:
       address: http://localhost:9411/
 
 property:
+  test2: from_microservice_yaml
   test4: from_microservice_yaml
   test5: from_microservice_yaml


### PR DESCRIPTION
Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/SCB) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[SCB-XXX] Fixes bug in ApproximateQuantiles`, where you replace `SCB-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean install` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---
See [SCB-521](https://issues.apache.org/jira/browse/SCB-521)
Config of SpringBoot should takes higher priority than microservice.yaml, so that the users converting SpringBoot project to ServiceComb don't have to add microservice.yaml to override the default config.
They can just write config in application.properties/yaml

![compile warning](https://issues.apache.org/jira/secure/attachment/12920784/ComplieWarning.PNG "compile warning")