### PR TITLE
[SCB-540] delete archetypes in java-chassis-dependencies pom

### DIFF
--- a/java-chassis-dependencies/pom.xml
+++ b/java-chassis-dependencies/pom.xml
@@ -1009,28 +1009,6 @@
         <artifactId>metrics-prometheus</artifactId>
         <version>1.0.0-m2-SNAPSHOT</version>
       </dependency>
-
-      <dependency>
-        <groupId>org.apache.servicecomb.archetypes</groupId>
-        <artifactId>business-service-jaxrs-archetype</artifactId>
-        <version>1.0.0-m2-SNAPSHOT</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.servicecomb.archetypes</groupId>
-        <artifactId>business-service-pojo-archetype</artifactId>
-        <version>1.0.0-m2-SNAPSHOT</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.servicecomb.archetypes</groupId>
-        <artifactId>business-service-springmvc-archetype</artifactId>
-        <version>1.0.0-m2-SNAPSHOT</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.servicecomb.archetypes</groupId>
-        <artifactId>business-service-spring-boot-starter-archetype</artifactId>
-        <version>1.0.0-m2-SNAPSHOT</version>
-      </dependency>
-
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
Signed-off-by: zhengyangyong <yangyong.zheng@huawei.com>

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/SCB) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[SCB-XXX] Fixes bug in ApproximateQuantiles`, where you replace `SCB-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean install` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---
It's a mistake that is unnecessary for add archetypes into java-chassis-dependencies, we need delete them.
```xml
<dependency>
<groupId>org.apache.servicecomb.archetypes</groupId>
<artifactId>business-service-jaxrs-archetype</artifactId>
<version>1.0.0-m2-SNAPSHOT</version>
</dependency>
<dependency>
<groupId>org.apache.servicecomb.archetypes</groupId>
<artifactId>business-service-pojo-archetype</artifactId>
<version>1.0.0-m2-SNAPSHOT</version>
</dependency>
<dependency>
<groupId>org.apache.servicecomb.archetypes</groupId>
<artifactId>business-service-springmvc-archetype</artifactId>
<version>1.0.0-m2-SNAPSHOT</version>
</dependency>
<dependency>
<groupId>org.apache.servicecomb.archetypes</groupId>
<artifactId>business-service-spring-boot-starter-archetype</artifactId>
<version>1.0.0-m2-SNAPSHOT</version>
</dependency>
```
