### PR TITLE
[SCB-538] Create SwaggerToClassGenerator

### DIFF
--- a/core/src/main/java/org/apache/servicecomb/core/definition/OperationMeta.java
+++ b/core/src/main/java/org/apache/servicecomb/core/definition/OperationMeta.java
@@ -68,9 +68,7 @@ public class OperationMeta {
 
     executor = ExecutorManager.findExecutor(this);
 
-    responsesMeta.init(schemaMeta.getMicroserviceMeta().getClassLoader(),
-        schemaMeta.getPackageName(),
-        schemaMeta.getSwagger(),
+    responsesMeta.init(schemaMeta.getSwaggerToClassGenerator(),
         swaggerOperation,
         method.getGenericReturnType());
   }

--- a/core/src/main/java/org/apache/servicecomb/core/definition/schema/AbstractSchemaFactory.java
+++ b/core/src/main/java/org/apache/servicecomb/core/definition/schema/AbstractSchemaFactory.java
@@ -30,7 +30,6 @@ import org.apache.servicecomb.serviceregistry.api.Const;
 import org.apache.servicecomb.swagger.generator.core.CompositeSwaggerGeneratorContext;
 import org.apache.servicecomb.swagger.generator.core.SwaggerGenerator;
 import org.apache.servicecomb.swagger.generator.core.SwaggerGeneratorContext;
-import org.apache.servicecomb.swagger.generator.core.utils.ClassUtils;
 
 import io.swagger.models.Swagger;
 
@@ -108,8 +107,6 @@ public abstract class AbstractSchemaFactory<CONTEXT extends SchemaContext> {
         SchemaUtils.generatePackageName(context.getMicroserviceMeta(), context.getSchemaId()));
     generator.generate();
 
-    // 确保接口是存在的
-    ClassUtils.getOrCreateInterface(generator);
     return generator;
   }
 }

--- a/core/src/main/java/org/apache/servicecomb/core/definition/schema/ProducerSchemaFactory.java
+++ b/core/src/main/java/org/apache/servicecomb/core/definition/schema/ProducerSchemaFactory.java
@@ -79,7 +79,7 @@ public class ProducerSchemaFactory extends AbstractSchemaFactory<ProducerSchemaC
 
     SchemaMeta schemaMeta = getOrCreateSchema(context);
 
-    SwaggerProducer producer = swaggerEnv.createProducer(producerInstance, schemaMeta.getSwagger());
+    SwaggerProducer producer = swaggerEnv.createProducer(producerInstance, schemaMeta.getSwaggerIntf());
     Executor reactiveExecutor = BeanUtils.getBean(ExecutorManager.EXECUTOR_REACTIVE);
     for (OperationMeta operationMeta : schemaMeta.getOperations()) {
       SwaggerProducerOperation producerOperation = producer.findOperation(operationMeta.getOperationId());

--- a/core/src/test/java/org/apache/servicecomb/core/TestDefinition.java
+++ b/core/src/test/java/org/apache/servicecomb/core/TestDefinition.java
@@ -83,7 +83,8 @@ public class TestDefinition {
     Info oInfo = new Info();
     oInfo.setVendorExtension("x-java-interface", "java.lang.String");
     oSwagger.setInfo(oInfo);
-    Assert.assertEquals("java.lang.String", (ClassUtils.getJavaInterface(oSwagger)).getName());
+    Assert.assertEquals("java.lang.String",
+        (ClassUtils.getInterfaceName(oSwagger.getInfo().getVendorExtensions())));
     oInfo.setVendorExtension("x-java-class", "java.lang.String");
   }
 }

--- a/integration-tests/test-common/pom.xml
+++ b/integration-tests/test-common/pom.xml
@@ -64,6 +64,10 @@
       <groupId>io.zipkin.brave</groupId>
       <artifactId>brave-context-log4j12</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/swagger/swagger-generator/generator-core/src/main/java/org/apache/servicecomb/swagger/converter/Converter.java
+++ b/swagger/swagger-generator/generator-core/src/main/java/org/apache/servicecomb/swagger/converter/Converter.java
@@ -19,10 +19,8 @@ package org.apache.servicecomb.swagger.converter;
 
 import com.fasterxml.jackson.databind.JavaType;
 
-import io.swagger.models.Swagger;
-
 public interface Converter {
   // def可能是property或model
   // def不可能为null
-  JavaType convert(ClassLoader classLoader, String packageName, Swagger swagger, Object def);
+  JavaType convert(SwaggerToClassGenerator swaggerToClassGenerator, Object def);
 }

--- a/swagger/swagger-generator/generator-core/src/main/java/org/apache/servicecomb/swagger/converter/ConverterMgr.java
+++ b/swagger/swagger-generator/generator-core/src/main/java/org/apache/servicecomb/swagger/converter/ConverterMgr.java
@@ -38,17 +38,14 @@ import org.apache.servicecomb.swagger.converter.property.RefPropertyConverter;
 import org.apache.servicecomb.swagger.converter.property.StringPropertyConverter;
 import org.apache.servicecomb.swagger.extend.property.ByteProperty;
 import org.apache.servicecomb.swagger.extend.property.ShortProperty;
-import org.apache.servicecomb.swagger.generator.core.SwaggerGenerator;
 
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.type.SimpleType;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 
 import io.swagger.models.ArrayModel;
-import io.swagger.models.Model;
 import io.swagger.models.ModelImpl;
 import io.swagger.models.RefModel;
-import io.swagger.models.Swagger;
 import io.swagger.models.parameters.BodyParameter;
 import io.swagger.models.parameters.CookieParameter;
 import io.swagger.models.parameters.FormParameter;
@@ -167,7 +164,7 @@ public final class ConverterMgr {
       throw new Error("not support inner property class: " + propertyCls.getName());
     }
 
-    converterMap.put(propertyCls, (classLoader, packageName, swagger, def) -> javaType);
+    converterMap.put(propertyCls, (context, def) -> javaType);
   }
 
   public static void addConverter(Class<?> cls, Converter converter) {
@@ -179,16 +176,9 @@ public final class ConverterMgr {
     return TYPE_FORMAT_MAP.get(key);
   }
 
-  public static JavaType findJavaType(SwaggerGenerator generator, Object def) {
-    return findJavaType(generator.getClassLoader(),
-        generator.ensureGetPackageName(),
-        generator.getSwagger(),
-        def);
-  }
-
   // def为null是void的场景
   // def可能是model、property、parameter
-  public static JavaType findJavaType(ClassLoader classLoader, String packageName, Swagger swagger, Object def) {
+  public static JavaType findJavaType(SwaggerToClassGenerator swaggerToClassGenerator, Object def) {
     if (def == null) {
       return VOID_JAVA_TYPE;
     }
@@ -197,14 +187,6 @@ public final class ConverterMgr {
       throw new Error("not support def type: " + def.getClass());
     }
 
-    return converter.convert(classLoader, packageName, swagger, def);
-  }
-
-  public static JavaType findByRef(ClassLoader classLoader, String packageName, Swagger swagger, String refName) {
-    Model ref = swagger.getDefinitions().get(refName);
-    if (ModelImpl.class.isInstance(ref) && ((ModelImpl) ref).getName() == null) {
-      ((ModelImpl) ref).setName(refName);
-    }
-    return findJavaType(classLoader, packageName, swagger, ref);
+    return converter.convert(swaggerToClassGenerator, def);
   }
 }

--- a/swagger/swagger-generator/generator-core/src/main/java/org/apache/servicecomb/swagger/converter/SwaggerToClassGenerator.java
+++ b/swagger/swagger-generator/generator-core/src/main/java/org/apache/servicecomb/swagger/converter/SwaggerToClassGenerator.java
@@ -1,0 +1,259 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.servicecomb.swagger.converter;
+
+import java.util.IdentityHashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.apache.servicecomb.common.javassist.ClassConfig;
+import org.apache.servicecomb.common.javassist.JavassistUtils;
+import org.apache.servicecomb.common.javassist.MethodConfig;
+import org.apache.servicecomb.swagger.generator.core.SwaggerConst;
+import org.apache.servicecomb.swagger.generator.core.utils.ClassUtils;
+import org.springframework.util.StringUtils;
+
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.type.TypeFactory;
+import com.google.common.annotations.VisibleForTesting;
+
+import io.swagger.models.Model;
+import io.swagger.models.Operation;
+import io.swagger.models.Path;
+import io.swagger.models.Response;
+import io.swagger.models.Swagger;
+import io.swagger.models.parameters.Parameter;
+import io.swagger.models.properties.Property;
+
+/**
+ * generate interface from swagger<br>
+ * specially should support:<br>
+ * <pre>
+ * 1. recursive dependency:
+ *   1). class A {
+ *     A a;
+ *   }
+ *   2). circular dependency:
+ *   class A {
+ *     B b;
+ *   }
+ *   class B {
+ *     A a;
+ *   }
+ * 2. CustomerGeneric&lt;T1, T2&gt;
+ *    should generate 3 classes: CustomerGeneric/T1/T2
+ *    this can avoid unnecessary convert between consumer/contract/producer
+ * </pre>
+ *
+ * javassist can create normal dynamic class to classloader<br>
+ * but can not create recursive dependency dynamic class to classloader directly<br>
+ * to support recursive dependency, must save all class to byte[], and then convert to class<br>
+ *
+ */
+public class SwaggerToClassGenerator {
+  private ClassLoader classLoader;
+
+  private Swagger swagger;
+
+  /**
+   * package for definitions that no x-java-class attribute
+   */
+  private String packageName;
+
+  /**
+   * if not set, then will get from swagger.info.vendorExtensions.x-java-interface
+   * if still not set, then will use ${packageName}.SchemaInterface
+   */
+  private String interfaceName;
+
+  private Class<?> interfaceCls;
+
+  private TypeFactory typeFactory;
+
+  // key is swagger model or property
+  @VisibleForTesting
+  protected Map<Object, JavaType> swaggerObjectMap = new IdentityHashMap<>();
+
+  /**
+   *
+   * @param classLoader
+   * @param swagger
+   * @param packageName package for definitions that no x-java-class attribute
+   */
+  public SwaggerToClassGenerator(ClassLoader classLoader, Swagger swagger, String packageName) {
+    this.classLoader = classLoader;
+    this.swagger = swagger;
+    this.packageName = packageName;
+
+    this.typeFactory = TypeFactory.defaultInstance().withClassLoader(classLoader);
+  }
+
+  public void setInterfaceName(String interfaceName) {
+    this.interfaceName = interfaceName;
+  }
+
+  public ClassLoader getClassLoader() {
+    return classLoader;
+  }
+
+  public Swagger getSwagger() {
+    return swagger;
+  }
+
+  public String getPackageName() {
+    return packageName;
+  }
+
+  public TypeFactory getTypeFactory() {
+    return typeFactory;
+  }
+
+  public Class<?> getInterfaceCls() {
+    return interfaceCls;
+  }
+
+  /**
+   * convert definitions/parameters and responses to java class
+   * convert swagger to interface
+   */
+  public Class<?> convert() {
+    collectInterfaceName();
+    mapDefinitionsToExistingClasses();
+    convertDefinitions();
+    convertResponses();
+    convertToInterface();
+
+    return interfaceCls;
+  }
+
+  protected void collectInterfaceName() {
+    if (interfaceName != null) {
+      return;
+    }
+
+    if (swagger.getInfo() != null) {
+      interfaceName = ClassUtils.getInterfaceName(swagger.getInfo().getVendorExtensions());
+      if (interfaceName != null) {
+        return;
+      }
+    }
+
+    interfaceName = packageName + ".SchemaInterface";
+  }
+
+  protected void mapDefinitionsToExistingClasses() {
+    interfaceCls = ClassUtils.getClassByName(classLoader, interfaceName);
+    if (interfaceCls == null) {
+      return;
+    }
+
+    // TODO: map
+  }
+
+  protected void convertDefinitions() {
+    if (swagger.getDefinitions() == null) {
+      return;
+    }
+
+    for (Entry<String, Model> entry : swagger.getDefinitions().entrySet()) {
+      convertModel(entry.getKey(), entry.getValue());
+    }
+  }
+
+  protected void convertResponses() {
+    if (swagger.getPaths() == null) {
+      return;
+    }
+
+    for (Path path : swagger.getPaths().values()) {
+      for (Operation operation : path.getOperations()) {
+        for (Response response : operation.getResponses().values()) {
+          convert(response.getSchema());
+
+          Map<String, Property> headers = response.getHeaders();
+          if (headers == null) {
+            continue;
+          }
+          for (Property header : headers.values()) {
+            convert(header);
+          }
+        }
+      }
+    }
+  }
+
+  protected void convertToInterface() {
+    if (interfaceCls != null) {
+      return;
+    }
+
+    ClassConfig classConfig = new ClassConfig();
+    classConfig.setClassName(interfaceName);
+    classConfig.setIntf(true);
+
+    if (swagger.getPaths() != null) {
+      for (Path path : swagger.getPaths().values()) {
+        for (Operation operation : path.getOperations()) {
+          Response result = operation.getResponses().get(SwaggerConst.SUCCESS_KEY);
+          JavaType resultJavaType = swaggerObjectMap.get(result.getSchema());
+
+          MethodConfig methodConfig = new MethodConfig();
+          methodConfig.setName(operation.getOperationId());
+          methodConfig.setResult(resultJavaType);
+
+          for (Parameter parameter : operation.getParameters()) {
+            String paramName = parameter.getName();
+            paramName = ClassUtils.correctMethodParameterName(paramName);
+
+            JavaType paramJavaType = ConverterMgr.findJavaType(this, parameter);
+            methodConfig.addParameter(paramName, paramJavaType);
+          }
+
+          classConfig.addMethod(methodConfig);
+        }
+      }
+    }
+
+    interfaceCls = JavassistUtils.createClass(classLoader, classConfig);
+  }
+
+  public JavaType convert(Object swaggerObject) {
+    JavaType javaType = swaggerObjectMap.get(swaggerObject);
+    if (javaType == null) {
+      javaType = ConverterMgr.findJavaType(this, swaggerObject);
+      swaggerObjectMap.put(swaggerObject, javaType);
+    }
+    return javaType;
+  }
+
+  protected void updateJavaClassInVendor(Map<String, Object> vendorExtensions, String shortClsName) {
+    String clsName = ClassUtils.getClassName(vendorExtensions);
+    if (StringUtils.isEmpty(clsName)) {
+      vendorExtensions.put(SwaggerConst.EXT_JAVA_CLASS, packageName + "." + shortClsName);
+    }
+  }
+
+  protected JavaType convertModel(String name, Model model) {
+    updateJavaClassInVendor(model.getVendorExtensions(), name);
+    return convert(model);
+  }
+
+  public JavaType convertRef(String ref) {
+    return convertModel(ref, swagger.getDefinitions().get(ref));
+  }
+}

--- a/swagger/swagger-generator/generator-core/src/main/java/org/apache/servicecomb/swagger/converter/model/ArrayModelConverter.java
+++ b/swagger/swagger-generator/generator-core/src/main/java/org/apache/servicecomb/swagger/converter/model/ArrayModelConverter.java
@@ -17,24 +17,20 @@
 
 package org.apache.servicecomb.swagger.converter.model;
 
+import org.apache.servicecomb.swagger.converter.SwaggerToClassGenerator;
 import org.apache.servicecomb.swagger.converter.property.ArrayPropertyConverter;
 
 import com.fasterxml.jackson.databind.JavaType;
 
 import io.swagger.models.ArrayModel;
-import io.swagger.models.Swagger;
 
 public class ArrayModelConverter extends AbstractModelConverter {
   @Override
-  public JavaType doConvert(ClassLoader classLoader, String packageName, Swagger swagger, Object model) {
+  public JavaType doConvert(SwaggerToClassGenerator swaggerToClassGenerator, Object model) {
     ArrayModel arrayModel = (ArrayModel) model;
 
     if (arrayModel.getItems() != null) {
-      return ArrayPropertyConverter.findJavaType(classLoader,
-          packageName,
-          swagger,
-          arrayModel.getItems(),
-          false);
+      return ArrayPropertyConverter.findJavaType(swaggerToClassGenerator, arrayModel.getItems(), false);
     }
 
     // don't know when will this happen.

--- a/swagger/swagger-generator/generator-core/src/main/java/org/apache/servicecomb/swagger/converter/model/ModelImplConverter.java
+++ b/swagger/swagger-generator/generator-core/src/main/java/org/apache/servicecomb/swagger/converter/model/ModelImplConverter.java
@@ -17,22 +17,26 @@
 
 package org.apache.servicecomb.swagger.converter.model;
 
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.apache.servicecomb.common.javassist.ClassConfig;
+import org.apache.servicecomb.common.javassist.JavassistUtils;
 import org.apache.servicecomb.swagger.converter.ConverterMgr;
+import org.apache.servicecomb.swagger.converter.SwaggerToClassGenerator;
 import org.apache.servicecomb.swagger.converter.property.MapPropertyConverter;
-import org.apache.servicecomb.swagger.generator.core.SwaggerConst;
 import org.apache.servicecomb.swagger.generator.core.utils.ClassUtils;
-import org.springframework.util.StringUtils;
 
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 
 import io.swagger.models.ModelImpl;
-import io.swagger.models.Swagger;
 import io.swagger.models.properties.ObjectProperty;
+import io.swagger.models.properties.Property;
 
 public class ModelImplConverter extends AbstractModelConverter {
   @Override
-  public JavaType doConvert(ClassLoader classLoader, String packageName, Swagger swagger, Object model) {
+  public JavaType doConvert(SwaggerToClassGenerator swaggerToClassGenerator, Object model) {
     ModelImpl modelImpl = (ModelImpl) model;
 
     JavaType javaType = ConverterMgr.findJavaType(modelImpl.getType(), modelImpl.getFormat());
@@ -41,14 +45,11 @@ public class ModelImplConverter extends AbstractModelConverter {
     }
 
     if (modelImpl.getReference() != null) {
-      return ConverterMgr.findByRef(classLoader, packageName, swagger, modelImpl.getReference());
+      return swaggerToClassGenerator.convertRef(modelImpl.getReference());
     }
 
     if (modelImpl.getAdditionalProperties() != null) {
-      return MapPropertyConverter.findJavaType(classLoader,
-          packageName,
-          swagger,
-          modelImpl.getAdditionalProperties());
+      return MapPropertyConverter.findJavaType(swaggerToClassGenerator, modelImpl.getAdditionalProperties());
     }
 
     if (ObjectProperty.TYPE.equals(modelImpl.getType())
@@ -57,30 +58,36 @@ public class ModelImplConverter extends AbstractModelConverter {
       return TypeFactory.defaultInstance().constructType(Object.class);
     }
 
-    return getOrCreateType(classLoader, packageName, swagger, modelImpl);
+    return getOrCreateType(swaggerToClassGenerator, modelImpl);
   }
 
-  protected String getOrCreateClassName(String packageName, ModelImpl modelImpl) throws Error {
-    // dynamic create class by name and property
-    // try to use x-java-class first
-    // if not defined then use new class name
-    String canonical = ClassUtils.getVendorExtension(findVendorExtensions(modelImpl), SwaggerConst.EXT_JAVA_CLASS);
-    if (!StringUtils.isEmpty(canonical)) {
-      return canonical;
-    }
-
-    if (packageName == null) {
-      throw new IllegalStateException("packageName should not be null");
-    }
-    return packageName + "." + modelImpl.getName();
-  }
-
-  protected JavaType getOrCreateType(ClassLoader classLoader, String packageName, Swagger swagger, ModelImpl modelImpl)
-      throws Error {
-    String clsName = getOrCreateClassName(packageName, modelImpl);
+  protected JavaType getOrCreateType(SwaggerToClassGenerator swaggerToClassGenerator, ModelImpl modelImpl) {
+    String clsName = ClassUtils.getClassName(findVendorExtensions(modelImpl));
     clsName = ClassUtils.correctClassName(clsName);
-    Class<?> cls =
-        ClassUtils.getOrCreateClass(classLoader, packageName, swagger, modelImpl.getProperties(), clsName);
+
+    Class<?> cls = getOrCreateClass(swaggerToClassGenerator, modelImpl.getProperties(), clsName);
     return TypeFactory.defaultInstance().constructType(cls);
+  }
+
+  protected Class<?> getOrCreateClass(SwaggerToClassGenerator swaggerToClassGenerator,
+      Map<String, Property> properties,
+      String clsName) {
+    Class<?> cls = ClassUtils.getClassByName(swaggerToClassGenerator.getClassLoader(), clsName);
+    if (cls != null) {
+      return cls;
+    }
+
+    ClassConfig classConfig = new ClassConfig();
+    classConfig.setClassName(clsName);
+
+    if (null != properties) {
+      for (Entry<String, Property> entry : properties.entrySet()) {
+        JavaType propertyJavaType = swaggerToClassGenerator.convert(entry.getValue());
+        classConfig.addField(entry.getKey(), propertyJavaType);
+      }
+    }
+
+    cls = JavassistUtils.createClass(swaggerToClassGenerator.getClassLoader(), classConfig);
+    return cls;
   }
 }

--- a/swagger/swagger-generator/generator-core/src/main/java/org/apache/servicecomb/swagger/converter/model/RefModelConverter.java
+++ b/swagger/swagger-generator/generator-core/src/main/java/org/apache/servicecomb/swagger/converter/model/RefModelConverter.java
@@ -17,18 +17,15 @@
 
 package org.apache.servicecomb.swagger.converter.model;
 
-import org.apache.servicecomb.swagger.converter.ConverterMgr;
+import org.apache.servicecomb.swagger.converter.SwaggerToClassGenerator;
 
 import com.fasterxml.jackson.databind.JavaType;
 
 import io.swagger.models.RefModel;
-import io.swagger.models.Swagger;
 
 public class RefModelConverter extends AbstractModelConverter {
   @Override
-  public JavaType doConvert(ClassLoader classLoader, String packageName, Swagger swagger, Object model) {
-    RefModel refModel = (RefModel) model;
-
-    return ConverterMgr.findByRef(classLoader, packageName, swagger, refModel.getSimpleRef());
+  public JavaType doConvert(SwaggerToClassGenerator swaggerToClassGenerator, Object refModel) {
+    return swaggerToClassGenerator.convertRef(((RefModel) refModel).getSimpleRef());
   }
 }

--- a/swagger/swagger-generator/generator-core/src/main/java/org/apache/servicecomb/swagger/converter/parameter/AbstractSerializableParameterConverter.java
+++ b/swagger/swagger-generator/generator-core/src/main/java/org/apache/servicecomb/swagger/converter/parameter/AbstractSerializableParameterConverter.java
@@ -19,12 +19,12 @@ package org.apache.servicecomb.swagger.converter.parameter;
 
 import org.apache.servicecomb.swagger.converter.Converter;
 import org.apache.servicecomb.swagger.converter.ConverterMgr;
+import org.apache.servicecomb.swagger.converter.SwaggerToClassGenerator;
 import org.apache.servicecomb.swagger.converter.property.ArrayPropertyConverter;
 import org.apache.servicecomb.swagger.converter.property.StringPropertyConverter;
 
 import com.fasterxml.jackson.databind.JavaType;
 
-import io.swagger.models.Swagger;
 import io.swagger.models.parameters.AbstractSerializableParameter;
 import io.swagger.models.properties.ArrayProperty;
 import io.swagger.models.properties.StringProperty;
@@ -32,20 +32,16 @@ import io.swagger.models.properties.StringProperty;
 public class AbstractSerializableParameterConverter implements Converter {
 
   @Override
-  public JavaType convert(ClassLoader classLoader, String packageName, Swagger swagger, Object def) {
+  public JavaType convert(SwaggerToClassGenerator swaggerToClassGenerator, Object def) {
     AbstractSerializableParameter<?> param = (AbstractSerializableParameter<?>) def;
 
     switch (param.getType()) {
       case ArrayProperty.TYPE:
-        return ArrayPropertyConverter.findJavaType(classLoader,
-            packageName,
-            swagger,
+        return ArrayPropertyConverter.findJavaType(swaggerToClassGenerator,
             param.getItems(),
             param.isUniqueItems());
       case StringProperty.TYPE:
-        return StringPropertyConverter.findJavaType(classLoader,
-            packageName,
-            swagger,
+        return StringPropertyConverter.findJavaType(swaggerToClassGenerator,
             param.getType(),
             param.getFormat(),
             param.getEnum());

--- a/swagger/swagger-generator/generator-core/src/main/java/org/apache/servicecomb/swagger/converter/parameter/BodyParameterConverter.java
+++ b/swagger/swagger-generator/generator-core/src/main/java/org/apache/servicecomb/swagger/converter/parameter/BodyParameterConverter.java
@@ -18,18 +18,17 @@
 package org.apache.servicecomb.swagger.converter.parameter;
 
 import org.apache.servicecomb.swagger.converter.Converter;
-import org.apache.servicecomb.swagger.converter.ConverterMgr;
+import org.apache.servicecomb.swagger.converter.SwaggerToClassGenerator;
 
 import com.fasterxml.jackson.databind.JavaType;
 
-import io.swagger.models.Swagger;
 import io.swagger.models.parameters.BodyParameter;
 
 public class BodyParameterConverter implements Converter {
 
   @Override
-  public JavaType convert(ClassLoader classLoader, String packageName, Swagger swagger, Object def) {
+  public JavaType convert(SwaggerToClassGenerator swaggerToClassGenerator, Object def) {
     BodyParameter param = (BodyParameter) def;
-    return ConverterMgr.findJavaType(classLoader, packageName, swagger, param.getSchema());
+    return swaggerToClassGenerator.convert(param.getSchema());
   }
 }

--- a/swagger/swagger-generator/generator-core/src/main/java/org/apache/servicecomb/swagger/converter/property/ArrayPropertyConverter.java
+++ b/swagger/swagger-generator/generator-core/src/main/java/org/apache/servicecomb/swagger/converter/property/ArrayPropertyConverter.java
@@ -21,20 +21,19 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
-import org.apache.servicecomb.swagger.converter.ConverterMgr;
+import org.apache.servicecomb.swagger.converter.SwaggerToClassGenerator;
 
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 
-import io.swagger.models.Swagger;
 import io.swagger.models.properties.ArrayProperty;
 import io.swagger.models.properties.Property;
 
 public class ArrayPropertyConverter extends AbstractPropertyConverter {
-  public static JavaType findJavaType(ClassLoader classLoader, String packageName, Swagger swagger,
+  public static JavaType findJavaType(SwaggerToClassGenerator swaggerToClassGenerator,
       Property itemProperty,
       Boolean uniqueItems) {
-    JavaType itemJavaType = ConverterMgr.findJavaType(classLoader, packageName, swagger, itemProperty);
+    JavaType itemJavaType = swaggerToClassGenerator.convert(itemProperty);
 
     @SuppressWarnings("rawtypes")
     Class<? extends Collection> collectionClass = List.class;
@@ -45,13 +44,9 @@ public class ArrayPropertyConverter extends AbstractPropertyConverter {
   }
 
   @Override
-  public JavaType doConvert(ClassLoader classLoader, String packageName, Swagger swagger, Object property) {
+  public JavaType doConvert(SwaggerToClassGenerator swaggerToClassGenerator, Object property) {
     ArrayProperty arrayProperty = (ArrayProperty) property;
 
-    return findJavaType(classLoader,
-        packageName,
-        swagger,
-        arrayProperty.getItems(),
-        arrayProperty.getUniqueItems());
+    return findJavaType(swaggerToClassGenerator, arrayProperty.getItems(), arrayProperty.getUniqueItems());
   }
 }

--- a/swagger/swagger-generator/generator-core/src/main/java/org/apache/servicecomb/swagger/converter/property/MapPropertyConverter.java
+++ b/swagger/swagger-generator/generator-core/src/main/java/org/apache/servicecomb/swagger/converter/property/MapPropertyConverter.java
@@ -19,29 +19,26 @@ package org.apache.servicecomb.swagger.converter.property;
 
 import java.util.Map;
 
-import org.apache.servicecomb.swagger.converter.ConverterMgr;
+import org.apache.servicecomb.swagger.converter.SwaggerToClassGenerator;
 
 import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.type.TypeFactory;
 
-import io.swagger.models.Swagger;
 import io.swagger.models.properties.MapProperty;
 import io.swagger.models.properties.Property;
 
 public class MapPropertyConverter extends AbstractPropertyConverter {
   @Override
-  public JavaType doConvert(ClassLoader classLoader, String packageName, Swagger swagger, Object property) {
+  public JavaType doConvert(SwaggerToClassGenerator swaggerToClassGenerator, Object property) {
     MapProperty mapProperty = (MapProperty) property;
     Property valueProperty = mapProperty.getAdditionalProperties();
-    return findJavaType(classLoader, packageName, swagger, valueProperty);
+    return findJavaType(swaggerToClassGenerator, valueProperty);
   }
 
-  public static JavaType findJavaType(ClassLoader classLoader, String packageName, Swagger swagger,
-      Property valueProperty) {
-    JavaType valueJavaType = ConverterMgr.findJavaType(classLoader, packageName, swagger, valueProperty);
+  public static JavaType findJavaType(SwaggerToClassGenerator swaggerToClassGenerator, Property valueProperty) {
+    JavaType valueJavaType = swaggerToClassGenerator.convert(valueProperty);
 
-    return TypeFactory.defaultInstance().constructMapType(Map.class,
-        TypeFactory.defaultInstance().constructType(String.class),
+    return swaggerToClassGenerator.getTypeFactory().constructMapType(Map.class,
+        swaggerToClassGenerator.getTypeFactory().constructType(String.class),
         valueJavaType);
   }
 }

--- a/swagger/swagger-generator/generator-core/src/main/java/org/apache/servicecomb/swagger/converter/property/ObjectPropertyConverter.java
+++ b/swagger/swagger-generator/generator-core/src/main/java/org/apache/servicecomb/swagger/converter/property/ObjectPropertyConverter.java
@@ -17,16 +17,14 @@
 package org.apache.servicecomb.swagger.converter.property;
 
 import org.apache.servicecomb.swagger.converter.Converter;
+import org.apache.servicecomb.swagger.converter.SwaggerToClassGenerator;
 
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 
-import io.swagger.models.Swagger;
-
 public class ObjectPropertyConverter implements Converter {
   @Override
-  public JavaType convert(ClassLoader classLoader, String packageName, Swagger swagger, Object def) {
+  public JavaType convert(SwaggerToClassGenerator swaggerToClassGenerator, Object def) {
     return TypeFactory.defaultInstance().constructType(Object.class);
   }
-
 }

--- a/swagger/swagger-generator/generator-core/src/main/java/org/apache/servicecomb/swagger/converter/property/RefPropertyConverter.java
+++ b/swagger/swagger-generator/generator-core/src/main/java/org/apache/servicecomb/swagger/converter/property/RefPropertyConverter.java
@@ -17,18 +17,15 @@
 
 package org.apache.servicecomb.swagger.converter.property;
 
-import org.apache.servicecomb.swagger.converter.ConverterMgr;
+import org.apache.servicecomb.swagger.converter.SwaggerToClassGenerator;
 
 import com.fasterxml.jackson.databind.JavaType;
 
-import io.swagger.models.Swagger;
 import io.swagger.models.properties.RefProperty;
 
 public class RefPropertyConverter extends AbstractPropertyConverter {
   @Override
-  public JavaType doConvert(ClassLoader classLoader, String packageName, Swagger swagger, Object property) {
-    RefProperty refProperty = (RefProperty) property;
-
-    return ConverterMgr.findByRef(classLoader, packageName, swagger, refProperty.getSimpleRef());
+  public JavaType doConvert(SwaggerToClassGenerator swaggerToClassGenerator, Object refProperty) {
+    return swaggerToClassGenerator.convertRef(((RefProperty) refProperty).getSimpleRef());
   }
 }

--- a/swagger/swagger-generator/generator-core/src/main/java/org/apache/servicecomb/swagger/converter/property/StringPropertyConverter.java
+++ b/swagger/swagger-generator/generator-core/src/main/java/org/apache/servicecomb/swagger/converter/property/StringPropertyConverter.java
@@ -21,22 +21,24 @@ import java.util.List;
 
 import org.apache.servicecomb.common.javassist.JavassistUtils;
 import org.apache.servicecomb.swagger.converter.ConverterMgr;
+import org.apache.servicecomb.swagger.converter.SwaggerToClassGenerator;
 
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 
-import io.swagger.models.Swagger;
 import io.swagger.models.properties.StringProperty;
 
 public class StringPropertyConverter extends AbstractPropertyConverter {
-  public static JavaType findJavaType(ClassLoader classLoader, String packageName, Swagger swagger, String type,
+  public static JavaType findJavaType(SwaggerToClassGenerator swaggerToClassGenerator, String type,
       String format, List<String> enums) {
     if (!isEnum(enums)) {
       return ConverterMgr.findJavaType(type, format);
     }
 
     // enum，且需要动态生成class
-    Class<?> enumCls = JavassistUtils.getOrCreateEnumWithPackageName(classLoader, packageName, enums);
+    Class<?> enumCls = JavassistUtils
+        .getOrCreateEnumWithPackageName(swaggerToClassGenerator.getClassLoader(),
+            swaggerToClassGenerator.getPackageName(), enums);
     return TypeFactory.defaultInstance().constructType(enumCls);
   }
 
@@ -49,13 +51,11 @@ public class StringPropertyConverter extends AbstractPropertyConverter {
   }
 
   @Override
-  public JavaType doConvert(ClassLoader classLoader, String packageName, Swagger swagger, Object property) {
+  public JavaType doConvert(SwaggerToClassGenerator swaggerToClassGenerator, Object property) {
     StringProperty stringProperty = (StringProperty) property;
 
     List<String> enums = stringProperty.getEnum();
-    return findJavaType(classLoader,
-        packageName,
-        swagger,
+    return findJavaType(swaggerToClassGenerator,
         stringProperty.getType(),
         stringProperty.getFormat(),
         enums);

--- a/swagger/swagger-generator/generator-core/src/main/java/org/apache/servicecomb/swagger/generator/core/unittest/UnitTestSwaggerUtils.java
+++ b/swagger/swagger-generator/generator-core/src/main/java/org/apache/servicecomb/swagger/generator/core/unittest/UnitTestSwaggerUtils.java
@@ -41,8 +41,13 @@ public final class UnitTestSwaggerUtils {
   }
 
   public static SwaggerGenerator generateSwagger(Class<?> cls) {
+    return generateSwagger(Thread.currentThread().getContextClassLoader(), cls);
+  }
+
+  public static SwaggerGenerator generateSwagger(ClassLoader classLoader, Class<?> cls) {
     SwaggerGeneratorContext context = compositeContext.selectContext(cls);
     SwaggerGenerator generator = new SwaggerGenerator(context, cls);
+    generator.setClassLoader(classLoader);
     generator.generate();
 
     return generator;

--- a/swagger/swagger-generator/generator-core/src/main/java/org/apache/servicecomb/swagger/generator/core/utils/ClassUtils.java
+++ b/swagger/swagger-generator/generator-core/src/main/java/org/apache/servicecomb/swagger/generator/core/utils/ClassUtils.java
@@ -45,9 +45,6 @@ import io.swagger.models.parameters.Parameter;
 import io.swagger.models.properties.Property;
 
 public final class ClassUtils {
-  // reference:
-  //  https://docs.oracle.com/javase/tutorial/java/nutsandbolts/_keywords.html
-  //  https://en.wikipedia.org/wiki/List_of_Java_keywords
   private ClassUtils() {
   }
 

--- a/swagger/swagger-generator/generator-core/src/main/java/org/apache/servicecomb/swagger/generator/core/utils/ClassUtils.java
+++ b/swagger/swagger-generator/generator-core/src/main/java/org/apache/servicecomb/swagger/generator/core/utils/ClassUtils.java
@@ -21,14 +21,13 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 
 import javax.lang.model.SourceVersion;
 
 import org.apache.servicecomb.common.javassist.ClassConfig;
 import org.apache.servicecomb.common.javassist.JavassistUtils;
-import org.apache.servicecomb.common.javassist.MethodConfig;
 import org.apache.servicecomb.swagger.converter.ConverterMgr;
+import org.apache.servicecomb.swagger.converter.SwaggerToClassGenerator;
 import org.apache.servicecomb.swagger.generator.core.OperationGenerator;
 import org.apache.servicecomb.swagger.generator.core.SwaggerConst;
 import org.apache.servicecomb.swagger.generator.core.SwaggerGenerator;
@@ -36,13 +35,8 @@ import org.springframework.util.StringUtils;
 
 import com.fasterxml.jackson.databind.JavaType;
 
-import io.swagger.models.Operation;
-import io.swagger.models.Path;
-import io.swagger.models.Response;
-import io.swagger.models.Swagger;
 import io.swagger.models.parameters.BodyParameter;
 import io.swagger.models.parameters.Parameter;
-import io.swagger.models.properties.Property;
 
 public final class ClassUtils {
   private ClassUtils() {
@@ -57,33 +51,6 @@ public final class ClassUtils {
     } catch (ClassNotFoundException e) {
       return null;
     }
-  }
-
-  // 获取modelImpl对应的class
-  public static Class<?> getOrCreateClass(ClassLoader classLoader, String packageName, Swagger swagger,
-      Map<String, Property> properties,
-      String clsName) {
-    Class<?> cls = getClassByName(classLoader, clsName);
-    if (cls != null) {
-      return cls;
-    }
-
-    ClassConfig classConfig = new ClassConfig();
-    classConfig.setClassName(clsName);
-
-    if (null != properties) {
-      for (Entry<String, Property> entry : properties.entrySet()) {
-        JavaType propertyJavaType =
-            ConverterMgr.findJavaType(classLoader,
-                packageName,
-                swagger,
-                entry.getValue());
-        classConfig.addField(entry.getKey(), propertyJavaType);
-      }
-    }
-
-    cls = JavassistUtils.createClass(classLoader, classConfig);
-    return cls;
   }
 
   // 将一系列body parameter包装成一个class
@@ -102,11 +69,10 @@ public final class ClassUtils {
 
     // 1.全是预备body
     // 2.预备body与明确body混合
+    SwaggerToClassGenerator classGenerator = new SwaggerToClassGenerator(swaggerGenerator.getClassLoader(),
+        swaggerGenerator.getSwagger(), swaggerGenerator.ensureGetPackageName());
     for (BodyParameter bp : bodyParameters) {
-      JavaType javaType = ConverterMgr.findJavaType(swaggerGenerator.getClassLoader(),
-          swaggerGenerator.ensureGetPackageName(),
-          swaggerGenerator.getSwagger(),
-          bp);
+      JavaType javaType = ConverterMgr.findJavaType(classGenerator, bp);
       classConfig.addField(bp.getName(), javaType);
     }
 
@@ -135,18 +101,12 @@ public final class ClassUtils {
     return false;
   }
 
-  public static Class<?> getJavaInterface(Swagger swagger) {
-    return getClassByVendorExtensions(null, swagger.getInfo().getVendorExtensions(), SwaggerConst.EXT_JAVA_INTF);
+  public static String getClassName(Map<String, Object> vendorExtensions) {
+    return getVendorExtension(vendorExtensions, SwaggerConst.EXT_JAVA_CLASS);
   }
 
-  public static Class<?> getClassByVendorExtensions(ClassLoader classLoader, Map<String, Object> vendorExtensions,
-      String clsKey) {
-    String clsName = getVendorExtension(vendorExtensions, clsKey);
-    if (StringUtils.isEmpty(clsName)) {
-      return null;
-    }
-
-    return getClassByName(classLoader, clsName);
+  public static String getInterfaceName(Map<String, Object> vendorExtensions) {
+    return getVendorExtension(vendorExtensions, SwaggerConst.EXT_JAVA_INTF);
   }
 
   public static String getRawClassName(String canonical) {
@@ -175,81 +135,20 @@ public final class ClassUtils {
     return (T) vendorExtensions.get(key);
   }
 
-  public static Class<?> getOrCreateInterface(SwaggerGenerator generator) {
-    return getOrCreateInterface(generator.getSwagger(),
-        generator.getClassLoader(),
-        generator.ensureGetPackageName());
-  }
-
-  public static Class<?> getOrCreateInterface(Swagger swagger, ClassLoader classLoader, String packageName) {
-    String intfName =
-        (String) swagger.getInfo().getVendorExtensions().get(SwaggerConst.EXT_JAVA_INTF);
-    Class<?> intf = getClassByName(classLoader, intfName);
-    if (intf != null) {
-      return intf;
-    }
-
-    if (packageName == null) {
-      int idx = intfName.lastIndexOf(".");
-      if (idx == -1) {
-        packageName = "";
-      } else {
-        packageName = intfName.substring(0, idx);
-      }
-    }
-    return createInterface(swagger, classLoader, packageName, intfName);
-  }
-
-  private static Class<?> createInterface(Swagger swagger, ClassLoader classLoader, String packageName,
-      String intfName) {
-    ClassConfig classConfig = new ClassConfig();
-    classConfig.setClassName(intfName);
-    classConfig.setIntf(true);
-
-    for (Path path : swagger.getPaths().values()) {
-      for (Operation operation : path.getOperations()) {
-        // 参数可能重名，所以packageName必须跟operation相关才能隔离
-        String opPackageName = packageName + "." + operation.getOperationId();
-
-        Response result = operation.getResponses().get(SwaggerConst.SUCCESS_KEY);
-        JavaType resultJavaType = ConverterMgr.findJavaType(classLoader,
-            opPackageName,
-            swagger,
-            result.getSchema());
-
-        MethodConfig methodConfig = new MethodConfig();
-        methodConfig.setName(operation.getOperationId());
-        methodConfig.setResult(resultJavaType);
-
-        for (Parameter parameter : operation.getParameters()) {
-          String paramName = parameter.getName();
-          paramName = correctMethodParameterName(paramName);
-
-          JavaType paramJavaType = ConverterMgr.findJavaType(classLoader,
-              opPackageName,
-              swagger,
-              parameter);
-          methodConfig.addParameter(paramName, paramJavaType);
-        }
-
-        classConfig.addMethod(methodConfig);
-      }
-    }
-
-    return JavassistUtils.createClass(classLoader, classConfig);
-  }
-
   public static String correctMethodParameterName(String paramName) {
     if (SourceVersion.isName(paramName)) {
       return paramName;
     }
-    StringBuffer newParam = new StringBuffer();
-    char tempChar;
+
+    StringBuilder newParam = new StringBuilder();
     for (int index = 0; index < paramName.length(); index++) {
-      tempChar = paramName.charAt(index);
+      char tempChar = paramName.charAt(index);
       if (Character.isJavaIdentifierPart(tempChar)) {
         newParam.append(paramName.charAt(index));
-      } else if (tempChar == '.' || tempChar == '-') {
+        continue;
+      }
+
+      if (tempChar == '.' || tempChar == '-') {
         newParam.append('_');
       }
     }

--- a/swagger/swagger-generator/generator-core/src/main/java/org/apache/servicecomb/swagger/generator/pojo/converter/parameter/PendingBodyParameterConverter.java
+++ b/swagger/swagger-generator/generator-core/src/main/java/org/apache/servicecomb/swagger/generator/pojo/converter/parameter/PendingBodyParameterConverter.java
@@ -18,18 +18,16 @@
 package org.apache.servicecomb.swagger.generator.pojo.converter.parameter;
 
 import org.apache.servicecomb.swagger.converter.Converter;
-import org.apache.servicecomb.swagger.converter.ConverterMgr;
+import org.apache.servicecomb.swagger.converter.SwaggerToClassGenerator;
 import org.apache.servicecomb.swagger.generator.pojo.extend.parameter.PendingBodyParameter;
 
 import com.fasterxml.jackson.databind.JavaType;
 
-import io.swagger.models.Swagger;
-
 public class PendingBodyParameterConverter implements Converter {
 
   @Override
-  public JavaType convert(ClassLoader classLoader, String packageName, Swagger swagger, Object def) {
+  public JavaType convert(SwaggerToClassGenerator swaggerToClassGenerator, Object def) {
     PendingBodyParameter param = (PendingBodyParameter) def;
-    return ConverterMgr.findJavaType(classLoader, packageName, swagger, param.getProperty());
+    return swaggerToClassGenerator.convert(param.getProperty());
   }
 }

--- a/swagger/swagger-generator/generator-core/src/test/java/org/apache/servicecomb/swagger/converter/TestAbstractConverter.java
+++ b/swagger/swagger-generator/generator-core/src/test/java/org/apache/servicecomb/swagger/converter/TestAbstractConverter.java
@@ -27,7 +27,6 @@ import org.junit.Test;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 
-import io.swagger.models.Swagger;
 import mockit.Mocked;
 
 public class TestAbstractConverter {
@@ -38,6 +37,8 @@ public class TestAbstractConverter {
   ClassLoader classLoader = new ClassLoader() {
   };
 
+  SwaggerToClassGenerator swaggerToClassGenerator = new SwaggerToClassGenerator(classLoader, null, null);
+
   AbstractConverter converter = new AbstractConverter() {
     @Override
     protected Map<String, Object> findVendorExtensions(Object def) {
@@ -45,7 +46,7 @@ public class TestAbstractConverter {
     }
 
     @Override
-    protected JavaType doConvert(ClassLoader classLoader, String packageName, Swagger swagger, Object def) {
+    protected JavaType doConvert(SwaggerToClassGenerator swaggerToClassGenerator, Object def) {
       return doConvertResult;
     }
   };
@@ -55,14 +56,14 @@ public class TestAbstractConverter {
     doConvertResult = TypeFactory.defaultInstance().constructType(String.class);
     vendorExtensions.put(SwaggerConst.EXT_JAVA_CLASS, "java.lang.String");
 
-    Assert.assertSame(doConvertResult, converter.convert(classLoader, null, null, null));
+    Assert.assertSame(doConvertResult, converter.convert(swaggerToClassGenerator, null));
   }
 
   @Test
   public void convert_noCanonical(@Mocked JavaType type) {
     doConvertResult = type;
 
-    Assert.assertSame(type, converter.convert(classLoader, null, null, null));
+    Assert.assertSame(type, converter.convert(swaggerToClassGenerator, null));
   }
 
   @Test
@@ -70,7 +71,7 @@ public class TestAbstractConverter {
     doConvertResult = TypeFactory.defaultInstance().constructParametricType(Optional.class, String.class);
     vendorExtensions.put(SwaggerConst.EXT_JAVA_CLASS, "java.util.Optional<java.lang.String>");
 
-    Assert.assertSame(doConvertResult, converter.convert(classLoader, null, null, null));
+    Assert.assertSame(doConvertResult, converter.convert(swaggerToClassGenerator, null));
   }
 
   @Test
@@ -78,6 +79,6 @@ public class TestAbstractConverter {
     doConvertResult = TypeFactory.defaultInstance().constructType(String.class);
     vendorExtensions.put(SwaggerConst.EXT_JAVA_CLASS, "xxx<java.lang.String>");
 
-    Assert.assertSame(doConvertResult, converter.convert(classLoader, null, null, null));
+    Assert.assertSame(doConvertResult, converter.convert(swaggerToClassGenerator, null));
   }
 }

--- a/swagger/swagger-generator/generator-core/src/test/java/org/apache/servicecomb/swagger/generator/core/ClassUtilsForTest.java
+++ b/swagger/swagger-generator/generator-core/src/test/java/org/apache/servicecomb/swagger/generator/core/ClassUtilsForTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.servicecomb.swagger.generator.core;
+
+import java.util.Map;
+
+import org.apache.servicecomb.swagger.converter.ConverterMgr;
+import org.apache.servicecomb.swagger.converter.SwaggerToClassGenerator;
+import org.apache.servicecomb.swagger.generator.core.utils.ClassUtils;
+import org.springframework.util.StringUtils;
+
+import com.fasterxml.jackson.databind.JavaType;
+
+import io.swagger.models.Swagger;
+
+public class ClassUtilsForTest {
+  public static Class<?> getOrCreateInterface(SwaggerGenerator generator) {
+    return getOrCreateInterface(generator.getSwagger(),
+        generator.getClassLoader(),
+        generator.ensureGetPackageName());
+  }
+
+  public static Class<?> getOrCreateInterface(Swagger swagger, ClassLoader classLoader,
+      String packageName) {
+    String intfName = ClassUtils.getInterfaceName(swagger.getInfo().getVendorExtensions());
+    Class<?> intf = ClassUtils.getClassByName(classLoader, intfName);
+    if (intf != null) {
+      return intf;
+    }
+
+    if (packageName == null) {
+      int idx = intfName.lastIndexOf(".");
+      if (idx == -1) {
+        packageName = "";
+      } else {
+        packageName = intfName.substring(0, idx);
+      }
+    }
+
+    SwaggerToClassGenerator swaggerToClassGenerator = new SwaggerToClassGenerator(classLoader, swagger, packageName);
+    swaggerToClassGenerator.setInterfaceName(intfName);
+    return swaggerToClassGenerator.convert();
+  }
+
+  public static Class<?> getClassByVendorExtensions(ClassLoader classLoader, Map<String, Object> vendorExtensions,
+      String clsKey) {
+    String clsName = ClassUtils.getVendorExtension(vendorExtensions, clsKey);
+    if (StringUtils.isEmpty(clsName)) {
+      return null;
+    }
+
+    return ClassUtils.getClassByName(classLoader, clsName);
+  }
+
+  public static JavaType findJavaType(SwaggerGenerator generator, Object def) {
+    return ConverterMgr.findJavaType(new SwaggerToClassGenerator(generator.getClassLoader(), generator.getSwagger(),
+        generator.ensureGetPackageName()), def);
+  }
+}

--- a/swagger/swagger-generator/generator-core/src/test/java/org/apache/servicecomb/swagger/generator/core/TestApiImplicitParams.java
+++ b/swagger/swagger-generator/generator-core/src/test/java/org/apache/servicecomb/swagger/generator/core/TestApiImplicitParams.java
@@ -17,7 +17,6 @@
 
 package org.apache.servicecomb.swagger.generator.core;
 
-import org.apache.servicecomb.swagger.converter.ConverterMgr;
 import org.apache.servicecomb.swagger.generator.core.schema.User;
 import org.apache.servicecomb.swagger.generator.core.unittest.SwaggerGeneratorForTest;
 import org.apache.servicecomb.swagger.generator.pojo.PojoSwaggerGeneratorContext;
@@ -56,7 +55,7 @@ public class TestApiImplicitParams {
     Operation operation = path.getOperations().get(0);
     Parameter parameter = operation.getParameters().get(0);
 
-    JavaType javaType = ConverterMgr.findJavaType(swaggerGenerator, parameter);
+    JavaType javaType = ClassUtilsForTest.findJavaType(swaggerGenerator, parameter);
     Assert.assertEquals(User.class, javaType.getRawClass());
   }
 }

--- a/swagger/swagger-generator/generator-core/src/test/java/org/apache/servicecomb/swagger/generator/core/TestApiResponse.java
+++ b/swagger/swagger-generator/generator-core/src/test/java/org/apache/servicecomb/swagger/generator/core/TestApiResponse.java
@@ -17,7 +17,6 @@
 
 package org.apache.servicecomb.swagger.generator.core;
 
-import org.apache.servicecomb.swagger.converter.ConverterMgr;
 import org.apache.servicecomb.swagger.generator.core.unittest.SwaggerGeneratorForTest;
 import org.apache.servicecomb.swagger.generator.pojo.PojoSwaggerGeneratorContext;
 import org.junit.Assert;
@@ -79,7 +78,7 @@ public class TestApiResponse {
 
     Response response = operation.getResponses().get("200");
     Property property = response.getHeaders().get("k1");
-    Assert.assertEquals(Integer.class, ConverterMgr.findJavaType(generator, property).getRawClass());
+    Assert.assertEquals(Integer.class, ClassUtilsForTest.findJavaType(generator, property).getRawClass());
   }
 
   private void checkResponseDesc(SwaggerGenerator generator) {
@@ -103,10 +102,10 @@ public class TestApiResponse {
 
     Response response = operation.getResponses().get("200");
     Property property = response.getHeaders().get("k1");
-    Assert.assertEquals(Integer.class, ConverterMgr.findJavaType(generator, property).getRawClass());
+    Assert.assertEquals(Integer.class, ClassUtilsForTest.findJavaType(generator, property).getRawClass());
 
     property = response.getHeaders().get("k2");
-    Assert.assertEquals(String.class, ConverterMgr.findJavaType(generator, property).getRawClass());
+    Assert.assertEquals(String.class, ClassUtilsForTest.findJavaType(generator, property).getRawClass());
   }
 
   public void checkSingle(SwaggerGenerator generator) {
@@ -117,7 +116,7 @@ public class TestApiResponse {
     Assert.assertEquals("testSingle", operation.getOperationId());
 
     Response response = operation.getResponses().get("200");
-    Assert.assertEquals(Integer.class, ConverterMgr.findJavaType(generator, response.getSchema()).getRawClass());
+    Assert.assertEquals(Integer.class, ClassUtilsForTest.findJavaType(generator, response.getSchema()).getRawClass());
   }
 
   public void checkMulti(SwaggerGenerator generator) {
@@ -129,9 +128,9 @@ public class TestApiResponse {
     Assert.assertEquals("testMulti", operation.getOperationId());
 
     Response response = operation.getResponses().get("200");
-    Assert.assertEquals(Integer.class, ConverterMgr.findJavaType(generator, response.getSchema()).getRawClass());
+    Assert.assertEquals(Integer.class, ClassUtilsForTest.findJavaType(generator, response.getSchema()).getRawClass());
 
     response = operation.getResponses().get("301");
-    Assert.assertEquals(String.class, ConverterMgr.findJavaType(generator, response.getSchema()).getRawClass());
+    Assert.assertEquals(String.class, ClassUtilsForTest.findJavaType(generator, response.getSchema()).getRawClass());
   }
 }

--- a/swagger/swagger-generator/generator-core/src/test/java/org/apache/servicecomb/swagger/generator/core/TestArrayType.java
+++ b/swagger/swagger-generator/generator-core/src/test/java/org/apache/servicecomb/swagger/generator/core/TestArrayType.java
@@ -21,7 +21,6 @@ import java.lang.reflect.Method;
 import org.apache.servicecomb.foundation.common.utils.ReflectUtils;
 import org.apache.servicecomb.swagger.generator.core.schema.ArrayType;
 import org.apache.servicecomb.swagger.generator.core.unittest.UnitTestSwaggerUtils;
-import org.apache.servicecomb.swagger.generator.core.utils.ClassUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -32,7 +31,7 @@ public class TestArrayType {
   @Test
   public void test() throws Exception {
     SwaggerGenerator generator = UnitTestSwaggerUtils.generateSwagger(ArrayType.class);
-    Class<?> cls = ClassUtils.getOrCreateInterface(generator);
+    Class<?> cls = ClassUtilsForTest.getOrCreateInterface(generator);
     Method method = ReflectUtils.findMethod(cls, "testBytes");
 
     Class<?> param = (Class<?>) method.getParameters()[0].getParameterizedType();

--- a/swagger/swagger-generator/generator-core/src/test/java/org/apache/servicecomb/swagger/generator/core/TestClassUtils.java
+++ b/swagger/swagger-generator/generator-core/src/test/java/org/apache/servicecomb/swagger/generator/core/TestClassUtils.java
@@ -50,67 +50,6 @@ import mockit.Deencapsulation;
 
 @SwaggerDefinition
 public class TestClassUtils {
-  // copy from ClassUtils
-  // do not use JAVA_RESERVED_WORDS in ClassUtils directly
-  // because that's the test target.
-  private static final Set<String> JAVA_RESERVED_WORDS = new HashSet<>();
-
-  static {
-    JAVA_RESERVED_WORDS.addAll(Arrays.asList("true",
-        "false",
-        "null",
-        "abstract",
-        "continue",
-        "for",
-        "new",
-        "switch",
-        "assert",
-        "default",
-        "goto",
-        "package",
-        "synchronized",
-        "boolean",
-        "do",
-        "if",
-        "private",
-        "this",
-        "break",
-        "double",
-        "implements",
-        "protected",
-        "throw",
-        "byte",
-        "else",
-        "import",
-        "public",
-        "throws",
-        "case",
-        "enum",
-        "instanceof",
-        "return",
-        "transient",
-        "catch",
-        "extends",
-        "int",
-        "short",
-        "try",
-        "char",
-        "final",
-        "interface",
-        "static",
-        "void",
-        "class",
-        "finally",
-        "long",
-        "strictfp",
-        "volatile",
-        "const",
-        "float",
-        "native",
-        "super",
-        "while"));
-  }
-
   ClassLoader classLoader = new ClassLoader() {
   };
 
@@ -166,7 +105,9 @@ public class TestClassUtils {
   }
 
   @Test
-  public void testCorrectClassNameReservedWords() {
+  public void testCorrectClassNameReservedWords() throws IllegalAccessException {
+    @SuppressWarnings("unchecked")
+    Set<String> JAVA_RESERVED_WORDS = (Set<String>) FieldUtils.readStaticField(SourceVersion.class, "keywords", true);
     String name = String.join(".", JAVA_RESERVED_WORDS);
     String expectResult = "_" + String.join("._", JAVA_RESERVED_WORDS);
 

--- a/swagger/swagger-generator/generator-core/src/test/java/org/apache/servicecomb/swagger/generator/core/TestProperty.java
+++ b/swagger/swagger-generator/generator-core/src/test/java/org/apache/servicecomb/swagger/generator/core/TestProperty.java
@@ -20,6 +20,7 @@ package org.apache.servicecomb.swagger.generator.core;
 import java.util.Arrays;
 import java.util.List;
 
+import org.apache.servicecomb.swagger.converter.SwaggerToClassGenerator;
 import org.apache.servicecomb.swagger.converter.property.StringPropertyConverter;
 import org.apache.servicecomb.swagger.generator.core.unittest.SwaggerGeneratorForTest;
 import org.apache.servicecomb.swagger.generator.pojo.PojoSwaggerGeneratorContext;
@@ -44,8 +45,10 @@ public class TestProperty {
     sp._enum(enums);
 
     StringPropertyConverter spc = new StringPropertyConverter();
-    JavaType jt =
-        spc.convert(generator.getClassLoader(), generator.ensureGetPackageName(), generator.getSwagger(), sp);
+    JavaType jt = spc.convert(
+        new SwaggerToClassGenerator(generator.getClassLoader(), generator.getSwagger(),
+            generator.ensureGetPackageName()),
+        sp);
 
     StringProperty spNew = (StringProperty) ModelConverters.getInstance().readAsProperty(jt);
     Assert.assertEquals(enums, spNew.getEnum());

--- a/swagger/swagger-generator/generator-core/src/test/java/org/apache/servicecomb/swagger/generator/core/TestSwaggerUtils.java
+++ b/swagger/swagger-generator/generator-core/src/test/java/org/apache/servicecomb/swagger/generator/core/TestSwaggerUtils.java
@@ -23,55 +23,17 @@ import java.util.Date;
 
 import org.apache.servicecomb.common.javassist.JavassistUtils;
 import org.apache.servicecomb.foundation.common.utils.ReflectUtils;
-import org.apache.servicecomb.swagger.converter.ConverterMgr;
 import org.apache.servicecomb.swagger.generator.core.schema.Color;
 import org.apache.servicecomb.swagger.generator.core.schema.InvalidResponseHeader;
 import org.apache.servicecomb.swagger.generator.core.schema.RepeatOperation;
 import org.apache.servicecomb.swagger.generator.core.schema.Schema;
-import org.apache.servicecomb.swagger.generator.core.schema.User;
-import org.apache.servicecomb.swagger.generator.core.unittest.SwaggerGeneratorForTest;
 import org.apache.servicecomb.swagger.generator.core.unittest.UnitTestSwaggerUtils;
-import org.apache.servicecomb.swagger.generator.core.utils.ClassUtils;
-import org.apache.servicecomb.swagger.generator.core.utils.ParamUtils;
 import org.apache.servicecomb.swagger.generator.pojo.PojoSwaggerGeneratorContext;
 import org.junit.Assert;
 import org.junit.Test;
 
-import com.fasterxml.jackson.databind.JavaType;
-
-import io.swagger.models.Model;
-import io.swagger.models.RefModel;
-import io.swagger.models.Swagger;
-
 public class TestSwaggerUtils {
   SwaggerGeneratorContext context = new PojoSwaggerGeneratorContext();
-
-  @Test
-  public void testConverter() {
-    SwaggerGenerator generator = new SwaggerGeneratorForTest(context, null);
-    Swagger swagger = generator.getSwagger();
-    ParamUtils.addDefinitions(swagger, User.class);
-    Model model = swagger.getDefinitions().get("User");
-    model.getVendorExtensions().clear();
-
-    JavaType javaType = ConverterMgr.findJavaType(generator, model);
-    checkJavaType(swagger, javaType);
-
-    RefModel refModel = new RefModel();
-    refModel.setReference("User");
-    javaType = ConverterMgr.findJavaType(generator, refModel);
-    checkJavaType(swagger, javaType);
-  }
-
-  protected void checkJavaType(Swagger swagger, JavaType javaType) {
-    Class<?> cls = javaType.getRawClass();
-    Field[] fields = cls.getFields();
-    Assert.assertEquals("gen.cse.ms.ut.User", cls.getName());
-    Assert.assertEquals("name", fields[0].getName());
-    Assert.assertEquals(String.class, fields[0].getType());
-    Assert.assertEquals("age", fields[1].getName());
-    Assert.assertEquals(Integer.class, fields[1].getType());
-  }
 
   private SwaggerGenerator testSchemaMethod(String resultName, String... methodNames) {
     return UnitTestSwaggerUtils.testSwagger("schemas/" + resultName + ".yaml",
@@ -126,7 +88,7 @@ public class TestSwaggerUtils {
   public void testEnum() {
     SwaggerGenerator generator = testSchemaMethod("enum", "testEnum");
     JavassistUtils.detach("gen.cse.ms.ut.SchemaIntf");
-    Class<?> intf = ClassUtils.getOrCreateInterface(generator);
+    Class<?> intf = ClassUtilsForTest.getOrCreateInterface(generator);
 
     Method method = ReflectUtils.findMethod(intf, "testEnum");
     Class<?> bodyCls = method.getParameterTypes()[0];
@@ -221,7 +183,7 @@ public class TestSwaggerUtils {
   public void testDate() {
     SwaggerGenerator generator = testSchemaMethod("date", "testDate");
     JavassistUtils.detach("gen.cse.ms.ut.SchemaIntf");
-    Class<?> intf = ClassUtils.getOrCreateInterface(generator);
+    Class<?> intf = ClassUtilsForTest.getOrCreateInterface(generator);
 
     Method method = ReflectUtils.findMethod(intf, "testDate");
     Assert.assertEquals(Date.class, method.getReturnType());

--- a/swagger/swagger-invocation/invocation-core/src/main/java/org/apache/servicecomb/swagger/engine/SwaggerEnvironment.java
+++ b/swagger/swagger-invocation/invocation-core/src/main/java/org/apache/servicecomb/swagger/engine/SwaggerEnvironment.java
@@ -25,9 +25,6 @@ import javax.inject.Inject;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.servicecomb.foundation.common.utils.BeanUtils;
 import org.apache.servicecomb.foundation.common.utils.ReflectUtils;
-import org.apache.servicecomb.swagger.generator.core.SwaggerGenerator;
-import org.apache.servicecomb.swagger.generator.core.unittest.UnitTestSwaggerUtils;
-import org.apache.servicecomb.swagger.generator.core.utils.ClassUtils;
 import org.apache.servicecomb.swagger.invocation.arguments.consumer.ConsumerArgumentsMapper;
 import org.apache.servicecomb.swagger.invocation.arguments.consumer.ConsumerArgumentsMapperFactory;
 import org.apache.servicecomb.swagger.invocation.arguments.producer.ProducerArgumentsMapper;
@@ -41,7 +38,6 @@ import org.apache.servicecomb.swagger.invocation.response.producer.ProducerRespo
 import org.springframework.stereotype.Component;
 
 import io.swagger.annotations.ApiOperation;
-import io.swagger.models.Swagger;
 
 @Component
 public class SwaggerEnvironment {
@@ -128,10 +124,9 @@ public class SwaggerEnvironment {
     return apiOperationAnnotation.nickname();
   }
 
-  public SwaggerProducer createProducer(Object producerInstance, Swagger swagger) {
+  public SwaggerProducer createProducer(Object producerInstance, Class<?> swaggerIntf) {
     Class<?> producerCls = BeanUtils.getImplClassFromBean(producerInstance);
     Map<String, Method> visibleProducerMethods = retrieveVisibleMethods(producerCls);
-    Class<?> swaggerIntf = ClassUtils.getOrCreateInterface(swagger, null, null);
 
     SwaggerProducer producer = new SwaggerProducer();
     producer.setProducerCls(producerCls);
@@ -167,14 +162,6 @@ public class SwaggerEnvironment {
     }
 
     return producer;
-  }
-
-  public SwaggerProducer createProducer(Object producerInstance) {
-    Class<?> producerCls = BeanUtils.getImplClassFromBean(producerInstance);
-    SwaggerGenerator producerGenerator = UnitTestSwaggerUtils.generateSwagger(producerCls);
-    Swagger swagger = producerGenerator.getSwagger();
-
-    return createProducer(producerInstance, swagger);
   }
 
   private Map<String, Method> retrieveVisibleMethods(Class<?> clazz) {

--- a/swagger/swagger-invocation/invocation-core/src/main/java/org/apache/servicecomb/swagger/invocation/response/ResponseMeta.java
+++ b/swagger/swagger-invocation/invocation-core/src/main/java/org/apache/servicecomb/swagger/invocation/response/ResponseMeta.java
@@ -20,12 +20,11 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import org.apache.servicecomb.swagger.converter.ConverterMgr;
+import org.apache.servicecomb.swagger.converter.SwaggerToClassGenerator;
 
 import com.fasterxml.jackson.databind.JavaType;
 
 import io.swagger.models.Response;
-import io.swagger.models.Swagger;
 import io.swagger.models.properties.Property;
 
 public class ResponseMeta {
@@ -36,17 +35,16 @@ public class ResponseMeta {
 
   private Map<String, JavaType> headers = new HashMap<>();
 
-  public void init(ClassLoader classLoader, String packageName, Swagger swagger, Response response) {
+  public void init(SwaggerToClassGenerator swaggerToClassGenerator, Response response) {
     if (javaType == null) {
-      Property property = response.getSchema();
-      javaType = ConverterMgr.findJavaType(classLoader, packageName, swagger, property);
+      javaType = swaggerToClassGenerator.convert(response.getSchema());
     }
 
     if (response.getHeaders() == null) {
       return;
     }
     for (Entry<String, Property> entry : response.getHeaders().entrySet()) {
-      JavaType headerJavaType = ConverterMgr.findJavaType(classLoader, packageName, swagger, entry.getValue());
+      JavaType headerJavaType = swaggerToClassGenerator.convert(entry.getValue());
       headers.put(entry.getKey(), headerJavaType);
     }
   }

--- a/swagger/swagger-invocation/invocation-core/src/main/java/org/apache/servicecomb/swagger/invocation/response/ResponsesMeta.java
+++ b/swagger/swagger-invocation/invocation-core/src/main/java/org/apache/servicecomb/swagger/invocation/response/ResponsesMeta.java
@@ -23,6 +23,7 @@ import java.util.Map.Entry;
 
 import javax.ws.rs.core.Response.Status;
 
+import org.apache.servicecomb.swagger.converter.SwaggerToClassGenerator;
 import org.apache.servicecomb.swagger.invocation.context.HttpStatus;
 import org.apache.servicecomb.swagger.invocation.exception.CommonExceptionData;
 
@@ -32,7 +33,6 @@ import com.fasterxml.jackson.databind.type.TypeFactory;
 
 import io.swagger.models.Operation;
 import io.swagger.models.Response;
-import io.swagger.models.Swagger;
 
 public class ResponsesMeta {
   private static final JavaType COMMON_EXCEPTION_JAVATYPE = SimpleType.constructUnsafe(CommonExceptionData.class);
@@ -44,20 +44,19 @@ public class ResponsesMeta {
   // 最后一个参数returnType用于兼容场景
   // 历史版本中swagger中定义的return可能没定义class名，此时consumer与swagger接口是一致的
   // 如果不传return类型进来，完全以swagger为标准，会导致生成的class不等于return
-  public void init(ClassLoader classLoader, String packageName, Swagger swagger, Operation operation,
-      Type returnType) {
+  public void init(SwaggerToClassGenerator swaggerToClassGenerator, Operation operation, Type returnType) {
     initSuccessResponse(returnType);
 
     for (Entry<String, Response> entry : operation.getResponses().entrySet()) {
       if ("default".equals(entry.getKey())) {
         defaultResponse = new ResponseMeta();
-        defaultResponse.init(classLoader, packageName, swagger, entry.getValue());
+        defaultResponse.init(swaggerToClassGenerator, entry.getValue());
         continue;
       }
 
       Integer statusCode = Integer.parseInt(entry.getKey());
       ResponseMeta responseMeta = responseMap.computeIfAbsent(statusCode, k -> new ResponseMeta());
-      responseMeta.init(classLoader, packageName, swagger, entry.getValue());
+      responseMeta.init(swaggerToClassGenerator, entry.getValue());
     }
 
     if (defaultResponse == null) {

--- a/swagger/swagger-invocation/invocation-core/src/test/java/org/apache/servicecomb/engine/SwaggerEnvironmentForTest.java
+++ b/swagger/swagger-invocation/invocation-core/src/test/java/org/apache/servicecomb/engine/SwaggerEnvironmentForTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.servicecomb.engine;
+
+import org.apache.servicecomb.foundation.common.utils.BeanUtils;
+import org.apache.servicecomb.swagger.converter.SwaggerToClassGenerator;
+import org.apache.servicecomb.swagger.engine.SwaggerEnvironment;
+import org.apache.servicecomb.swagger.engine.SwaggerProducer;
+import org.apache.servicecomb.swagger.engine.bootstrap.BootstrapNormal;
+import org.apache.servicecomb.swagger.generator.core.SwaggerGenerator;
+import org.apache.servicecomb.swagger.generator.core.unittest.UnitTestSwaggerUtils;
+
+import io.swagger.models.Swagger;
+
+public class SwaggerEnvironmentForTest {
+  private SwaggerEnvironment swaggerEnvironment = new BootstrapNormal().boot();
+
+  private ClassLoader classLoader = new ClassLoader() {
+  };
+
+  public ClassLoader getClassLoader() {
+    return classLoader;
+  }
+
+  public SwaggerEnvironment getSwaggerEnvironment() {
+    return swaggerEnvironment;
+  }
+
+  public SwaggerProducer createProducer(Object producerInstance) {
+    Class<?> producerCls = BeanUtils.getImplClassFromBean(producerInstance);
+    SwaggerGenerator producerGenerator = UnitTestSwaggerUtils.generateSwagger(classLoader, producerCls);
+    Swagger swagger = producerGenerator.getSwagger();
+
+    SwaggerToClassGenerator swaggerToClassGenerator = new SwaggerToClassGenerator(new ClassLoader() {
+    }, swagger, null);
+    return swaggerEnvironment.createProducer(producerInstance, swaggerToClassGenerator.convert());
+  }
+}

--- a/swagger/swagger-invocation/invocation-core/src/test/java/org/apache/servicecomb/engine/TestSwaggerEnvironment.java
+++ b/swagger/swagger-invocation/invocation-core/src/test/java/org/apache/servicecomb/engine/TestSwaggerEnvironment.java
@@ -22,21 +22,18 @@ import static org.hamcrest.core.IsNull.notNullValue;
 import static org.hamcrest.core.IsNull.nullValue;
 import static org.junit.Assert.assertThat;
 
-import org.apache.servicecomb.swagger.engine.SwaggerEnvironment;
 import org.apache.servicecomb.swagger.engine.SwaggerProducer;
-import org.apache.servicecomb.swagger.engine.bootstrap.BootstrapNormal;
 import org.apache.servicecomb.swagger.invocation.models.ProducerImpl;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class TestSwaggerEnvironment {
-  private static SwaggerEnvironment env;
+  private static SwaggerEnvironmentForTest env = new SwaggerEnvironmentForTest();
 
   private static SwaggerProducer producer;
 
   @BeforeClass
   public static void init() {
-    env = new BootstrapNormal().boot();
     producer = env.createProducer(new ProducerImpl());
   }
 

--- a/swagger/swagger-invocation/invocation-core/src/test/java/org/apache/servicecomb/swagger/invocation/arguments/TestPojoConsumerEqualProducer.java
+++ b/swagger/swagger-invocation/invocation-core/src/test/java/org/apache/servicecomb/swagger/invocation/arguments/TestPojoConsumerEqualProducer.java
@@ -21,10 +21,9 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
+import org.apache.servicecomb.engine.SwaggerEnvironmentForTest;
 import org.apache.servicecomb.swagger.engine.SwaggerConsumer;
-import org.apache.servicecomb.swagger.engine.SwaggerEnvironment;
 import org.apache.servicecomb.swagger.engine.SwaggerProducer;
-import org.apache.servicecomb.swagger.engine.bootstrap.BootstrapNormal;
 import org.apache.servicecomb.swagger.engine.unittest.LocalProducerInvoker;
 import org.apache.servicecomb.swagger.invocation.arguments.utils.Utils;
 import org.apache.servicecomb.swagger.invocation.context.ContextUtils;
@@ -37,7 +36,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class TestPojoConsumerEqualProducer {
-  private static SwaggerEnvironment env;
+  private static SwaggerEnvironmentForTest env = new SwaggerEnvironmentForTest();
 
   private static SwaggerProducer producer;
 
@@ -49,9 +48,8 @@ public class TestPojoConsumerEqualProducer {
 
   @BeforeClass
   public static void init() {
-    env = new BootstrapNormal().boot();
     producer = env.createProducer(new PojoImpl());
-    consumer = env.createConsumer(PojoConsumerIntf.class, producer.getSwaggerIntf());
+    consumer = env.getSwaggerEnvironment().createConsumer(PojoConsumerIntf.class, producer.getSwaggerIntf());
     invoker = new LocalProducerInvoker(consumer, producer);
     proxy = invoker.getProxy();
   }

--- a/swagger/swagger-invocation/invocation-core/src/test/java/org/apache/servicecomb/swagger/invocation/arguments/TestPojoConsumerEqualSwagger.java
+++ b/swagger/swagger-invocation/invocation-core/src/test/java/org/apache/servicecomb/swagger/invocation/arguments/TestPojoConsumerEqualSwagger.java
@@ -20,10 +20,9 @@ package org.apache.servicecomb.swagger.invocation.arguments;
 import java.util.Arrays;
 import java.util.List;
 
+import org.apache.servicecomb.engine.SwaggerEnvironmentForTest;
 import org.apache.servicecomb.swagger.engine.SwaggerConsumer;
-import org.apache.servicecomb.swagger.engine.SwaggerEnvironment;
 import org.apache.servicecomb.swagger.engine.SwaggerProducer;
-import org.apache.servicecomb.swagger.engine.bootstrap.BootstrapNormal;
 import org.apache.servicecomb.swagger.engine.unittest.LocalProducerInvoker;
 import org.apache.servicecomb.swagger.invocation.context.ContextUtils;
 import org.apache.servicecomb.swagger.invocation.context.InvocationContext;
@@ -35,7 +34,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class TestPojoConsumerEqualSwagger {
-  private static SwaggerEnvironment env;
+  private static SwaggerEnvironmentForTest env = new SwaggerEnvironmentForTest();
 
   private static SwaggerProducer producer;
 
@@ -47,9 +46,8 @@ public class TestPojoConsumerEqualSwagger {
 
   @BeforeClass
   public static void init() {
-    env = new BootstrapNormal().boot();
     producer = env.createProducer(new JaxrsImpl());
-    consumer = env.createConsumer(PojoConsumerIntf.class, producer.getSwaggerIntf());
+    consumer = env.getSwaggerEnvironment().createConsumer(PojoConsumerIntf.class, producer.getSwaggerIntf());
     invoker = new LocalProducerInvoker(consumer, producer);
     proxy = invoker.getProxy();
   }

--- a/swagger/swagger-invocation/invocation-core/src/test/java/org/apache/servicecomb/swagger/invocation/response/TestResponsesMeta.java
+++ b/swagger/swagger-invocation/invocation-core/src/test/java/org/apache/servicecomb/swagger/invocation/response/TestResponsesMeta.java
@@ -16,6 +16,7 @@
  */
 package org.apache.servicecomb.swagger.invocation.response;
 
+import org.apache.servicecomb.swagger.converter.SwaggerToClassGenerator;
 import org.apache.servicecomb.swagger.generator.core.SwaggerGenerator;
 import org.apache.servicecomb.swagger.generator.core.unittest.UnitTestSwaggerUtils;
 import org.apache.servicecomb.swagger.invocation.exception.CommonExceptionData;
@@ -48,8 +49,10 @@ public class TestResponsesMeta {
     Swagger swagger = generator.getSwagger();
     Operation operation = swagger.getPath("/add").getPost();
 
+    SwaggerToClassGenerator swaggerToClassGenerator = new SwaggerToClassGenerator(new ClassLoader() {
+    }, swagger, "ms.sid");
     ResponsesMeta meta = new ResponsesMeta();
-    meta.init(null, "gen", swagger, operation, int.class);
+    meta.init(swaggerToClassGenerator, operation, int.class);
 
     ResponseMeta resp = meta.findResponseMeta(200);
     Assert.assertEquals(int.class, resp.getJavaType().getRawClass());

--- a/swagger/swagger-invocation/invocation-core/src/test/resources/log4j.properties
+++ b/swagger/swagger-invocation/invocation-core/src/test/resources/log4j.properties
@@ -15,16 +15,10 @@
 # limitations under the License.
 #
 
-log4j.rootLogger=INFO, out, stdout
+log4j.rootLogger=INFO, stdout
 
 # CONSOLE appender not used by default
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=%d [%-15.15t] %-5p %-30.30c{1} - %m%n
 
-# File appender
-log4j.appender.out=org.apache.log4j.FileAppender
-log4j.appender.out.layout=org.apache.log4j.PatternLayout
-log4j.appender.out.layout.ConversionPattern=%d [%-15.15t] %-5p %-30.30c{1} - %m%n
-log4j.appender.out.file=target/test.log
-log4j.appender.out.append=true


### PR DESCRIPTION
preparing for create recursive dependency class

 javassist can create normal dynamic class to classloader
 but can not create recursive dependency dynamic class to classloader directly
 to support recursive dependency, must save all class to byte[], and then convert to class

by SwaggerToClassGenerator we can do this in future PR