### PR TITLE
[SCB-534] remove generate generic class from swagger related comments…

### DIFF
--- a/swagger/swagger-generator/generator-core/src/main/java/org/apache/servicecomb/swagger/converter/AbstractConverter.java
+++ b/swagger/swagger-generator/generator-core/src/main/java/org/apache/servicecomb/swagger/converter/AbstractConverter.java
@@ -20,24 +20,17 @@ package org.apache.servicecomb.swagger.converter;
 import java.util.Map;
 
 import org.apache.servicecomb.swagger.generator.core.utils.ClassUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.util.StringUtils;
 
 import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.type.TypeFactory;
 
 public abstract class AbstractConverter implements Converter {
-  private static final Logger LOGGER = LoggerFactory.getLogger(AbstractConverter.class);
-
   protected abstract Map<String, Object> findVendorExtensions(Object def);
 
   protected abstract JavaType doConvert(SwaggerToClassGenerator swaggerToClassGenerator, Object def);
 
   @Override
   public JavaType convert(SwaggerToClassGenerator swaggerToClassGenerator, Object def) {
-    TypeFactory typeFactory = swaggerToClassGenerator.getTypeFactory();
-
     Map<String, Object> vendorExtensions = findVendorExtensions(def);
     String canonical = ClassUtils.getClassName(vendorExtensions);
     if (!StringUtils.isEmpty(canonical)) {
@@ -47,29 +40,6 @@ public abstract class AbstractConverter implements Converter {
       }
     }
 
-    // ensure all depend model exist
-    // maybe create dynamic class by canonical
-    JavaType result = doConvert(swaggerToClassGenerator, def);
-
-    String rawClassName = ClassUtils.getRawClassName(canonical);
-    if (StringUtils.isEmpty(rawClassName)) {
-      return result;
-    }
-
-    try {
-      JavaType rawType = typeFactory.constructFromCanonical(rawClassName);
-
-      if (rawType.getRawClass().getTypeParameters().length > 0) {
-        return typeFactory.constructFromCanonical(canonical);
-      }
-
-      return result;
-    } catch (IllegalArgumentException e) {
-      LOGGER.info("failed to load generic class {}, use {}. cause: {}.",
-          rawClassName,
-          result.getGenericSignature(),
-          e.getMessage());
-      return result;
-    }
+    return doConvert(swaggerToClassGenerator, def);
   }
 }

--- a/swagger/swagger-generator/generator-core/src/main/java/org/apache/servicecomb/swagger/converter/SwaggerToClassGenerator.java
+++ b/swagger/swagger-generator/generator-core/src/main/java/org/apache/servicecomb/swagger/converter/SwaggerToClassGenerator.java
@@ -42,24 +42,18 @@ import io.swagger.models.properties.Property;
 
 /**
  * generate interface from swagger<br>
- * specially should support:<br>
+ * specially should support: recursive dependency<br>
  * <pre>
- * 1. recursive dependency:
- *   1). class A {
+ * 1.class A {
  *     A a;
  *   }
- *   2). circular dependency:
- *   class A {
+ * 2.class A {
  *     B b;
  *   }
  *   class B {
  *     A a;
  *   }
- * 2. CustomerGeneric&lt;T1, T2&gt;
- *    should generate 3 classes: CustomerGeneric/T1/T2
- *    this can avoid unnecessary convert between consumer/contract/producer
  * </pre>
- *
  * javassist can create normal dynamic class to classloader<br>
  * but can not create recursive dependency dynamic class to classloader directly<br>
  * to support recursive dependency, must save all class to byte[], and then convert to class<br>


### PR DESCRIPTION
unnecessary to generate generic class from swagger:

in normal process: already have related model, no need to create dynamically
in edge: create or not, there is no any difference