### PR TITLE
[SCB-654] bug fix: DiscoveryTree concurrency problems

### DIFF
--- a/foundations/foundation-common/src/main/java/org/apache/servicecomb/foundation/common/cache/VersionedCache.java
+++ b/foundations/foundation-common/src/main/java/org/apache/servicecomb/foundation/common/cache/VersionedCache.java
@@ -129,6 +129,10 @@ public class VersionedCache {
     return newCache.cacheVersion - cacheVersion > 0;
   }
 
+  public boolean isSameVersion(VersionedCache newCache) {
+    return newCache.cacheVersion == cacheVersion;
+  }
+
   public boolean isEmpty() {
     return isEmpty.isEmpty();
   }

--- a/foundations/foundation-common/src/test/java/org/apache/servicecomb/foundation/common/cache/TestVersionedCache.java
+++ b/foundations/foundation-common/src/test/java/org/apache/servicecomb/foundation/common/cache/TestVersionedCache.java
@@ -125,4 +125,14 @@ public class TestVersionedCache {
     Assert.assertFalse(cacheOld.isExpired(cacheOld));
     Assert.assertFalse(cacheNew.isExpired(cacheOld));
   }
+
+  @Test
+  public void isSameVersion() {
+    VersionedCache cacheOld = new VersionedCache().autoCacheVersion();
+    VersionedCache cacheNew = new VersionedCache().autoCacheVersion();
+    VersionedCache cacheSame = new VersionedCache().cacheVersion(cacheNew.cacheVersion());
+
+    Assert.assertFalse(cacheOld.isSameVersion(cacheNew));
+    Assert.assertTrue(cacheSame.isSameVersion(cacheNew));
+  }
 }

--- a/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/discovery/DiscoveryTreeNode.java
+++ b/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/discovery/DiscoveryTreeNode.java
@@ -23,7 +23,7 @@ import org.apache.servicecomb.foundation.common.cache.VersionedCache;
 import org.apache.servicecomb.foundation.common.concurrent.ConcurrentHashMapEx;
 
 public class DiscoveryTreeNode extends VersionedCache {
-  private boolean childrenInited;
+  private volatile boolean childrenInited;
 
   private int level;
 

--- a/service-registry/src/test/java/org/apache/servicecomb/serviceregistry/discovery/TestDiscoveryTree.java
+++ b/service-registry/src/test/java/org/apache/servicecomb/serviceregistry/discovery/TestDiscoveryTree.java
@@ -84,6 +84,23 @@ public class TestDiscoveryTree {
   }
 
   @Test
+  public void isMatch_existingNull() {
+    Assert.assertFalse(discoveryTree.isMatch(null, null));
+  }
+
+  @Test
+  public void isMatch_yes() {
+    parent.cacheVersion(1);
+    Assert.assertTrue(discoveryTree.isMatch(new DiscoveryTreeNode().cacheVersion(1), parent));
+  }
+
+  @Test
+  public void isMatch_no() {
+    parent.cacheVersion(0);
+    Assert.assertFalse(discoveryTree.isExpired(new DiscoveryTreeNode().cacheVersion(1), parent));
+  }
+
+  @Test
   public void isExpired_existingNull() {
     Assert.assertTrue(discoveryTree.isExpired(null, null));
   }
@@ -232,5 +249,37 @@ public class TestDiscoveryTree {
 
     discoveryTree.discovery(context, new VersionedCache().cacheVersion(0).name("input"));
     Assert.assertTrue(parent.children().isEmpty());
+  }
+
+  @Test
+  public void getOrCreateRoot_match() {
+    Deencapsulation.setField(discoveryTree, "root", parent);
+
+    DiscoveryTreeNode root = discoveryTree.getOrCreateRoot(parent);
+
+    Assert.assertSame(parent, root);
+  }
+
+  @Test
+  public void getOrCreateRoot_expired() {
+    Deencapsulation.setField(discoveryTree, "root", parent);
+
+    VersionedCache inputCache = new VersionedCache().cacheVersion(parent.cacheVersion() + 1);
+    DiscoveryTreeNode root = discoveryTree.getOrCreateRoot(inputCache);
+
+    Assert.assertEquals(inputCache.cacheVersion(), root.cacheVersion());
+    Assert.assertSame(Deencapsulation.getField(discoveryTree, "root"), root);
+  }
+
+
+  @Test
+  public void getOrCreateRoot_tempRoot() {
+    Deencapsulation.setField(discoveryTree, "root", parent);
+
+    VersionedCache inputCache = new VersionedCache().cacheVersion(parent.cacheVersion() - 1);
+    DiscoveryTreeNode root = discoveryTree.getOrCreateRoot(inputCache);
+
+    Assert.assertEquals(inputCache.cacheVersion(), root.cacheVersion());
+    Assert.assertNotSame(Deencapsulation.getField(discoveryTree, "root"), root);
   }
 }


### PR DESCRIPTION
1.did not assign tmpRoot inside lock again
2.because of version overflow, root newer than input can not express by: tmpRoot.cacheVersion() > inputCache.cacheVersion()