### PR TITLE
[SCB-705] consumer don't cache ReferenceConfig of an unregistered provider

### DIFF
--- a/core/src/test/java/org/apache/servicecomb/core/provider/consumer/TestConsumerProviderManager.java
+++ b/core/src/test/java/org/apache/servicecomb/core/provider/consumer/TestConsumerProviderManager.java
@@ -17,6 +17,8 @@
 
 package org.apache.servicecomb.core.provider.consumer;
 
+import static org.junit.Assert.fail;
+
 import java.util.Collections;
 
 import org.apache.servicecomb.core.Const;
@@ -24,16 +26,21 @@ import org.apache.servicecomb.core.definition.schema.ConsumerSchemaFactory;
 import org.apache.servicecomb.foundation.test.scaffolding.config.ArchaiusUtils;
 import org.apache.servicecomb.serviceregistry.RegistryUtils;
 import org.apache.servicecomb.serviceregistry.consumer.AppManager;
+import org.apache.servicecomb.serviceregistry.consumer.MicroserviceVersion;
+import org.apache.servicecomb.serviceregistry.consumer.MicroserviceVersionRule;
 import org.apache.servicecomb.serviceregistry.definition.DefinitionConst;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
 import com.google.common.eventbus.EventBus;
 
 import mockit.Expectations;
+import mockit.Mock;
+import mockit.MockUp;
 import mockit.Mocked;
 
 public class TestConsumerProviderManager {
@@ -71,6 +78,13 @@ public class TestConsumerProviderManager {
         result = Collections.emptyList();
       }
     };
+
+    new MockUp<MicroserviceVersionRule>() {
+      @Mock
+      MicroserviceVersion getLatestMicroserviceVersion() {
+        return Mockito.mock(MicroserviceVersion.class);
+      }
+    };
     return consumerProviderManager.createReferenceConfig("app:ms");
   }
 
@@ -95,5 +109,44 @@ public class TestConsumerProviderManager {
     Assert.assertEquals("app:ms", referenceConfig.getMicroserviceVersionRule().getMicroserviceName());
     Assert.assertEquals("1.0.0+", referenceConfig.getMicroserviceVersionRule().getVersionRule().getVersionRule());
     Assert.assertEquals(Const.RESTFUL, referenceConfig.getTransport());
+  }
+
+  @Test
+  public void createReferenceConfig_ProviderNotFound() {
+    EventBus eventBus = new EventBus();
+    AppManager appManager = new AppManager(eventBus);
+
+    ConsumerProviderManager consumerProviderManager = new ConsumerProviderManager();
+    consumerProviderManager.setAppManager(appManager);
+
+    new Expectations(RegistryUtils.class) {
+      {
+        RegistryUtils.findServiceInstances(anyString, anyString, DefinitionConst.VERSION_RULE_ALL, null);
+        result = Collections.emptyList();
+      }
+    };
+
+    new MockUp<MicroserviceVersionRule>() {
+      @Mock
+      String getAppId() {
+        return "aId";
+      }
+
+      @Mock
+      String getMicroserviceName() {
+        return "ms";
+      }
+    };
+
+    try {
+      consumerProviderManager.createReferenceConfig("app:ms");
+      fail("an IllegalStateException is expected!");
+    } catch (Exception e) {
+      Assert.assertEquals(IllegalStateException.class, e.getClass());
+      Assert.assertEquals(
+          "Probably invoke a service before it is registered, or no instance found for it, appId=aId, name=ms",
+          e.getMessage());
+      e.printStackTrace();
+    }
   }
 }


### PR DESCRIPTION
So that consumer can re-query provider from the service-center. And when the provider is registered, the invocation can be executed successfully.

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/SCB) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[SCB-XXX] Fixes bug in ApproximateQuantiles`, where you replace `SCB-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean install` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---
See details in [SCB-705](https://issues.apache.org/jira/browse/SCB-705)