### PR TITLE
[SCB-774] fix warn log caused by ReactiveExecutor

### DIFF
--- a/core/src/main/java/org/apache/servicecomb/core/executor/ReactiveExecutor.java
+++ b/core/src/main/java/org/apache/servicecomb/core/executor/ReactiveExecutor.java
@@ -17,15 +17,20 @@
 
 package org.apache.servicecomb.core.executor;
 
+import java.io.Closeable;
 import java.util.concurrent.Executor;
 
 /**
  * 用于在verticle中就地执行，不做多余的调度，这是性能最高的一种模型
  */
-public class ReactiveExecutor implements Executor {
+public class ReactiveExecutor implements Executor, Closeable {
 
   @Override
   public void execute(Runnable command) {
     command.run();
+  }
+
+  @Override
+  public void close() {
   }
 }

--- a/core/src/test/java/org/apache/servicecomb/core/provider/producer/TestProducerProviderManager.java
+++ b/core/src/test/java/org/apache/servicecomb/core/provider/producer/TestProducerProviderManager.java
@@ -29,7 +29,6 @@ import org.apache.servicecomb.core.definition.MicroserviceMeta;
 import org.apache.servicecomb.core.definition.MicroserviceMetaManager;
 import org.apache.servicecomb.core.definition.OperationMeta;
 import org.apache.servicecomb.core.executor.FixedThreadExecutor;
-import org.apache.servicecomb.core.executor.ReactiveExecutor;
 import org.apache.servicecomb.foundation.test.scaffolding.log.LogCollector;
 import org.junit.Assert;
 import org.junit.Test;
@@ -102,7 +101,7 @@ public class TestProducerProviderManager {
 
   @Test
   public void onBootEvent_close_unknown(@Mocked MicroserviceMeta microserviceMeta, @Mocked OperationMeta op1) {
-    Executor executor = new ReactiveExecutor();
+    Executor executor = new UnCloseableExecutor();
     new Expectations() {
       {
         microserviceMeta.getOperations();
@@ -121,8 +120,16 @@ public class TestProducerProviderManager {
     producerProviderManager.onBootEvent(event);
 
     Assert.assertEquals(
-        "Executor org.apache.servicecomb.core.executor.ReactiveExecutor do not support close or shutdown, it may block service shutdown.",
+        "Executor org.apache.servicecomb.core.provider.producer.TestProducerProviderManager$UnCloseableExecutor "
+            + "do not support close or shutdown, it may block service shutdown.",
         logCollector.getEvents().get(0).getMessage());
     logCollector.teardown();
+  }
+
+  public static class UnCloseableExecutor implements Executor {
+    @Override
+    public void execute(Runnable command) {
+      command.run();
+    }
   }
 }


### PR DESCRIPTION
Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/SCB) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[SCB-XXX] Fixes bug in ApproximateQuantiles`, where you replace `SCB-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean install` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---
See details in [SCB-774](https://issues.apache.org/jira/browse/SCB-774)

Let the ReactiveExecutor implement java.io.Closeable so that ProducerProviderManager does not print warn log.