### PR TITLE
[SCB-690] add check if connection is still connected before execute invocation

### DIFF
--- a/core/src/main/java/org/apache/servicecomb/core/Transport.java
+++ b/core/src/main/java/org/apache/servicecomb/core/Transport.java
@@ -17,6 +17,7 @@
 
 package org.apache.servicecomb.core;
 
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.servicecomb.swagger.invocation.AsyncResponse;
@@ -53,4 +54,6 @@ public interface Transport {
   void send(Invocation invocation, AsyncResponse asyncResp) throws Exception;
 
   AtomicInteger getConnectedCounter();
+
+  Set<String> getConnectedAddresses();
 }

--- a/core/src/test/java/org/apache/servicecomb/core/TestTransport.java
+++ b/core/src/test/java/org/apache/servicecomb/core/TestTransport.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.servicecomb.core.endpoint.EndpointsCache;
@@ -34,6 +35,7 @@ import org.apache.servicecomb.swagger.invocation.AsyncResponse;
 import org.junit.Assert;
 import org.junit.Test;
 
+import io.vertx.core.impl.ConcurrentHashSet;
 import mockit.Expectations;
 import mockit.Injectable;
 import mockit.Mocked;
@@ -50,6 +52,11 @@ public class TestTransport {
       @Override
       public AtomicInteger getConnectedCounter() {
         return new AtomicInteger(0);
+      }
+
+      @Override
+      public Set<String> getConnectedAddresses() {
+        return new ConcurrentHashSet<>();
       }
 
       @Override

--- a/foundations/foundation-vertx/src/main/java/org/apache/servicecomb/foundation/vertx/server/TcpServerConnection.java
+++ b/foundations/foundation-vertx/src/main/java/org/apache/servicecomb/foundation/vertx/server/TcpServerConnection.java
@@ -16,6 +16,7 @@
  */
 package org.apache.servicecomb.foundation.vertx.server;
 
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.servicecomb.foundation.common.event.EventManager;
@@ -34,7 +35,7 @@ public class TcpServerConnection extends TcpConnection {
 
   protected TcpParser splitter;
 
-  public void init(NetSocket netSocket, AtomicInteger connectedCounter) {
+  public void init(NetSocket netSocket, AtomicInteger connectedCounter, Set<String> connectedAddresses) {
     // currently, socket always be NetSocketImpl
     this.initNetSocket((NetSocketImpl) netSocket);
 
@@ -43,7 +44,7 @@ public class TcpServerConnection extends TcpConnection {
         remoteAddress,
         Thread.currentThread().getName());
     netSocket.exceptionHandler(e -> {
-      LOGGER.error("disconected from {}, in thread {}, cause {}",
+      LOGGER.error("exception from {}, in thread {}, cause {}",
           remoteAddress,
           Thread.currentThread().getName(),
           e.getMessage());
@@ -52,7 +53,7 @@ public class TcpServerConnection extends TcpConnection {
       LOGGER.error("disconected from {}, in thread {}",
           remoteAddress,
           Thread.currentThread().getName());
-
+      connectedAddresses.remove(remoteAddress);
       int connectedCount = connectedCounter.decrementAndGet();
       EventManager.post(new ClientEvent(remoteAddress, ConnectionEvent.Closed, TransportType.Highway, connectedCount));
     });

--- a/foundations/foundation-vertx/src/test/java/org/apache/servicecomb/foundation/vertx/server/TestTcpServer.java
+++ b/foundations/foundation-vertx/src/test/java/org/apache/servicecomb/foundation/vertx/server/TestTcpServer.java
@@ -18,6 +18,7 @@
 package org.apache.servicecomb.foundation.vertx.server;
 
 import java.net.InetSocketAddress;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.servicecomb.foundation.common.net.URIEndpointObject;
@@ -26,6 +27,7 @@ import org.junit.Test;
 
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
+import io.vertx.core.impl.ConcurrentHashSet;
 import io.vertx.core.net.NetServer;
 import io.vertx.core.net.NetServerOptions;
 import io.vertx.core.net.NetSocket;
@@ -35,15 +37,15 @@ import mockit.Mocked;
 public class TestTcpServer {
   static class TcpServerForTest extends TcpServer {
     public TcpServerForTest(URIEndpointObject endpointObject) {
-      super(endpointObject, new AtomicInteger());
+      super(endpointObject, new AtomicInteger(), new ConcurrentHashSet<>());
     }
 
     @Override
     protected TcpServerConnection createTcpServerConnection() {
       return new TcpServerConnection() {
         @Override
-        public void init(NetSocket netSocket, AtomicInteger connectedCounter) {
-          super.init(netSocket, connectedCounter);
+        public void init(NetSocket netSocket, AtomicInteger connectedCounter, Set<String> connectedAddresses) {
+          super.init(netSocket, connectedCounter, connectedAddresses);
         }
       };
     }

--- a/foundations/foundation-vertx/src/test/java/org/apache/servicecomb/foundation/vertx/server/TestTcpServerConnection.java
+++ b/foundations/foundation-vertx/src/test/java/org/apache/servicecomb/foundation/vertx/server/TestTcpServerConnection.java
@@ -21,6 +21,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Assert;
 import org.junit.Test;
 
+import io.vertx.core.impl.ConcurrentHashSet;
 import io.vertx.core.net.impl.NetSocketImpl;
 import mockit.Mocked;
 
@@ -31,7 +32,7 @@ public class TestTcpServerConnection {
     connection.setProtocol("p");
     connection.setZipName("z");
 
-    connection.init(netSocket, new AtomicInteger());
+    connection.init(netSocket, new AtomicInteger(), new ConcurrentHashSet<>());
 
     Assert.assertEquals(netSocket, connection.getNetSocket());
   }

--- a/transports/transport-highway/src/main/java/org/apache/servicecomb/transport/highway/HighwayServer.java
+++ b/transports/transport-highway/src/main/java/org/apache/servicecomb/transport/highway/HighwayServer.java
@@ -17,6 +17,7 @@
 
 package org.apache.servicecomb.transport.highway;
 
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.servicecomb.core.Endpoint;
@@ -27,8 +28,8 @@ import org.apache.servicecomb.foundation.vertx.server.TcpServerConnection;
 public class HighwayServer extends TcpServer {
   private Endpoint endpoint;
 
-  public HighwayServer(Endpoint endpoint, AtomicInteger connectedCounter) {
-    super((URIEndpointObject) endpoint.getAddress(), connectedCounter);
+  public HighwayServer(Endpoint endpoint, AtomicInteger connectedCounter, Set<String> connectedAddresses) {
+    super((URIEndpointObject) endpoint.getAddress(), connectedCounter, connectedAddresses);
     this.endpoint = endpoint;
   }
 

--- a/transports/transport-highway/src/main/java/org/apache/servicecomb/transport/highway/HighwayServerVerticle.java
+++ b/transports/transport-highway/src/main/java/org/apache/servicecomb/transport/highway/HighwayServerVerticle.java
@@ -18,6 +18,7 @@
 package org.apache.servicecomb.transport.highway;
 
 import java.net.InetSocketAddress;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.servicecomb.core.Const;
@@ -44,12 +45,16 @@ public class HighwayServerVerticle extends AbstractVerticle {
 
   private final AtomicInteger connectedCounter;
 
+  private final Set<String> connectedAddresses;
+
   public HighwayServerVerticle() {
-    this(CseContext.getInstance().getTransportManager().findTransport(Const.HIGHWAY).getConnectedCounter());
+    this(CseContext.getInstance().getTransportManager().findTransport(Const.HIGHWAY).getConnectedCounter(),
+        CseContext.getInstance().getTransportManager().findTransport(Const.HIGHWAY).getConnectedAddresses());
   }
 
-  public HighwayServerVerticle(AtomicInteger connectedCounter) {
+  public HighwayServerVerticle(AtomicInteger connectedCounter, Set<String> connectedAddresses) {
     this.connectedCounter = connectedCounter;
+    this.connectedAddresses = connectedAddresses;
   }
 
   @Override
@@ -79,7 +84,7 @@ public class HighwayServerVerticle extends AbstractVerticle {
       return;
     }
 
-    HighwayServer server = new HighwayServer(endpoint, connectedCounter);
+    HighwayServer server = new HighwayServer(endpoint, connectedCounter, connectedAddresses);
     server.init(vertx, SSL_KEY, ar -> {
       if (ar.succeeded()) {
         InetSocketAddress socketAddress = ar.result();

--- a/transports/transport-highway/src/test/java/org/apache/servicecomb/transport/highway/TestHighwayServerConnection.java
+++ b/transports/transport-highway/src/test/java/org/apache/servicecomb/transport/highway/TestHighwayServerConnection.java
@@ -96,6 +96,7 @@ public class TestHighwayServerConnection {
     }
   }
 
+
   @Test
   public void testReqeustHeaderError() throws Exception {
     header.setMsgType(MsgType.LOGIN);
@@ -192,6 +193,32 @@ public class TestHighwayServerConnection {
     Assert.assertNull(connection.getProtocol());
     Assert.assertNull(connection.getZipName());
     Assert.assertEquals(true, holder.value);
+  }
+
+  @Test
+  public void testConnectionClosed(@Mocked MicroserviceMeta microserviceMeta, @Mocked OperationMeta operationMeta,
+      @Mocked SchemaMeta schemaMeta) throws Exception {
+    header.setMsgType(MsgType.REQUEST);
+    Buffer headerBuffer = createBuffer(requestHeaderSchema, header);
+
+    Buffer bodyBuffer = Buffer.buffer();
+
+    Holder<Boolean> holder = new Holder<>();
+    new MockUp<HighwayServerInvoke>() {
+      @Mock
+      public boolean init(NetSocket netSocket, long msgId,
+          RequestHeader header, Buffer bodyBuffer) {
+        return true;
+      }
+
+      @Mock
+      public void execute() {
+        holder.value = true;
+      }
+    };
+
+    connection.handle(0, headerBuffer, bodyBuffer);
+    Assert.assertNull(holder.value);
   }
 
   @Test

--- a/transports/transport-highway/src/test/java/org/apache/servicecomb/transport/highway/TestHighwayServerConnection.java
+++ b/transports/transport-highway/src/test/java/org/apache/servicecomb/transport/highway/TestHighwayServerConnection.java
@@ -39,6 +39,7 @@ import org.junit.Test;
 import io.protostuff.LinkedBuffer;
 import io.protostuff.ProtobufOutput;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.impl.ConcurrentHashSet;
 import io.vertx.core.net.NetSocket;
 import io.vertx.core.net.impl.NetSocketImpl;
 import io.vertx.core.net.impl.SocketAddressImpl;
@@ -76,7 +77,7 @@ public class TestHighwayServerConnection {
       }
     };
     connection = new HighwayServerConnection(endpoint);
-    connection.init(netSocket, new AtomicInteger());
+    connection.init(netSocket, new AtomicInteger(), new ConcurrentHashSet<>());
 
     header = new RequestHeader();
   }
@@ -87,6 +88,7 @@ public class TestHighwayServerConnection {
     Buffer headerBuffer = createBuffer(requestHeaderSchema, header);
 
     try {
+      connection.getConnectedAddresses().add(connection.getNetSocket().remoteAddress().toString());
       connection.handle(0, headerBuffer, null);
       throw new Error("must error");
     } catch (Throwable e) {
@@ -101,10 +103,11 @@ public class TestHighwayServerConnection {
 
     headerBuffer.setByte(0, (byte) 100);
 
+    connection.getConnectedAddresses().add(connection.getNetSocket().remoteAddress().toString());
     connection.handle(0, headerBuffer, null);
 
-    Assert.assertEquals(null, connection.getProtocol());
-    Assert.assertEquals(null, connection.getZipName());
+    Assert.assertNull(connection.getProtocol());
+    Assert.assertNull(connection.getZipName());
   }
 
   @Test
@@ -117,6 +120,7 @@ public class TestHighwayServerConnection {
     body.setZipName("z");
     Buffer bodyBuffer = createBuffer(setParameterRequestSchema, body);
 
+    connection.getConnectedAddresses().add(connection.getNetSocket().remoteAddress().toString());
     connection.handle(0, headerBuffer, bodyBuffer);
 
     Assert.assertEquals("p", connection.getProtocol());
@@ -136,8 +140,8 @@ public class TestHighwayServerConnection {
 
     connection.handle(0, headerBuffer, bodyBuffer);
 
-    Assert.assertEquals(null, connection.getProtocol());
-    Assert.assertEquals(null, connection.getZipName());
+    Assert.assertNull(connection.getProtocol());
+    Assert.assertNull(connection.getZipName());
   }
 
   @Test
@@ -182,10 +186,11 @@ public class TestHighwayServerConnection {
       }
     };
 
+    connection.getConnectedAddresses().add(connection.getNetSocket().remoteAddress().toString());
     connection.handle(0, headerBuffer, bodyBuffer);
 
-    Assert.assertEquals(null, connection.getProtocol());
-    Assert.assertEquals(null, connection.getZipName());
+    Assert.assertNull(connection.getProtocol());
+    Assert.assertNull(connection.getZipName());
     Assert.assertEquals(true, holder.value);
   }
 
@@ -207,8 +212,8 @@ public class TestHighwayServerConnection {
 
     connection.handle(0, headerBuffer, bodyBuffer);
 
-    Assert.assertEquals(null, connection.getProtocol());
-    Assert.assertEquals(null, connection.getZipName());
+    Assert.assertNull(connection.getProtocol());
+    Assert.assertNull(connection.getZipName());
     Assert.assertEquals(false, holder.value);
   }
 

--- a/transports/transport-highway/src/test/java/org/apache/servicecomb/transport/highway/TestHighwayVerticle.java
+++ b/transports/transport-highway/src/test/java/org/apache/servicecomb/transport/highway/TestHighwayVerticle.java
@@ -32,6 +32,7 @@ import org.mockito.Mockito;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
+import io.vertx.core.impl.ConcurrentHashSet;
 import io.vertx.core.json.JsonObject;
 import mockit.Expectations;
 import mockit.Mocked;
@@ -40,7 +41,7 @@ public class TestHighwayVerticle {
   @Test
   public void testHighwayVerticle(@Mocked Transport transport, @Mocked Vertx vertx, @Mocked Context context,
       @Mocked JsonObject json) {
-    HighwayServerVerticle highwayVerticle = new HighwayServerVerticle(new AtomicInteger());
+    HighwayServerVerticle highwayVerticle = new HighwayServerVerticle(new AtomicInteger(), new ConcurrentHashSet<>());
     URIEndpointObject endpiontObject = new URIEndpointObject("highway://127.0.0.1:9090");
     new Expectations() {
       {

--- a/transports/transport-rest/transport-rest-vertx/src/test/java/org/apache/servicecomb/transport/rest/vertx/TestRestServerVerticle.java
+++ b/transports/transport-rest/transport-rest-vertx/src/test/java/org/apache/servicecomb/transport/rest/vertx/TestRestServerVerticle.java
@@ -39,6 +39,7 @@ import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpMethod;
+import io.vertx.core.impl.ConcurrentHashSet;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.Route;
 import io.vertx.ext.web.Router;
@@ -57,7 +58,7 @@ public class TestRestServerVerticle {
 
   @Before
   public void setUp() {
-    instance = new RestServerVerticle(new AtomicInteger());
+    instance = new RestServerVerticle(new AtomicInteger(), new ConcurrentHashSet<>());
     startFuture = Future.future();
 
     CseContext.getInstance().setTransportManager(new TransportManager());
@@ -90,7 +91,7 @@ public class TestRestServerVerticle {
         result = endpiont;
       }
     };
-    RestServerVerticle server = new RestServerVerticle(new AtomicInteger());
+    RestServerVerticle server = new RestServerVerticle(new AtomicInteger(), new ConcurrentHashSet<>());
     // process stuff done by Expectations
     server.init(vertx, context);
     server.start(startFuture);
@@ -117,7 +118,7 @@ public class TestRestServerVerticle {
         result = endpiont;
       }
     };
-    RestServerVerticle server = new RestServerVerticle(new AtomicInteger());
+    RestServerVerticle server = new RestServerVerticle(new AtomicInteger(), new ConcurrentHashSet<>());
     // process stuff done by Expectations
     server.init(vertx, context);
     server.start(startFuture);
@@ -144,7 +145,7 @@ public class TestRestServerVerticle {
         result = endpiont;
       }
     };
-    RestServerVerticle server = new RestServerVerticle(new AtomicInteger());
+    RestServerVerticle server = new RestServerVerticle(new AtomicInteger(), new ConcurrentHashSet<>());
     boolean status = false;
     try {
       server.init(vertx, context);
@@ -240,7 +241,7 @@ public class TestRestServerVerticle {
     Router router = Mockito.mock(Router.class);
     Mockito.when(router.route()).thenReturn(Mockito.mock(Route.class));
 
-    RestServerVerticle server = new RestServerVerticle(new AtomicInteger());
+    RestServerVerticle server = new RestServerVerticle(new AtomicInteger(), new ConcurrentHashSet<>());
 
     Deencapsulation.invoke(server, "mountCorsHandler", router);
     Assert.assertEquals(7, counter.get());

--- a/transports/transport-rest/transport-rest-vertx/src/test/java/org/apache/servicecomb/transport/rest/vertx/TestVertxRestDispatcher.java
+++ b/transports/transport-rest/transport-rest-vertx/src/test/java/org/apache/servicecomb/transport/rest/vertx/TestVertxRestDispatcher.java
@@ -319,6 +319,34 @@ public class TestVertxRestDispatcher {
   }
 
   @Test
+  public void onRequestButConnectionClosed(@Mocked Context context, @Mocked HttpServerRequest request,
+      @Mocked SocketAddress socketAdrress) {
+    Map<String, Object> map = new HashMap<>();
+    RoutingContext routingContext = new MockUp<RoutingContext>() {
+      @Mock
+      RoutingContext put(String key, Object obj) {
+        map.put(key, obj);
+        return null;
+      }
+
+      @Mock
+      HttpServerRequest request() {
+        return request;
+      }
+    }.getMockInstance();
+
+    new Expectations(VertxImpl.class) {
+      {
+        VertxImpl.context();
+        result = context;
+      }
+    };
+
+    Deencapsulation.invoke(dispatcher, "onRequest", routingContext);
+    Assert.assertFalse(invoked);
+  }
+
+  @Test
   public void testWrapResponseBody() {
     VertxRestDispatcher vertxRestDispatcher = new VertxRestDispatcher();
     String message = "abcd";


### PR DESCRIPTION
Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/SCB) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[SCB-XXX] Fixes bug in ApproximateQuantiles`, where you replace `SCB-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean install` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---

If connection closed before execute invocation, skip invoke it
**Mechanism :**
1. Add an `ConcurrentHashSet` named *connectedAddresses*  in each `Transport`, when consumer connection connected, add its address into it, and after it had close, remove its address from it.
2. before producer execute invocation, it will check whether the consumer address is still in *connectedAddresses*, if no, skip and return
